### PR TITLE
fix(aws): gracefully handle trailing slash in bucket_arn

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 locals {
   bucket_name     = length(var.bucket_name) > 0 ? var.bucket_name : "${var.prefix}-bucket-${random_id.uniq.hex}"
-  bucket_arn      = var.use_existing_cloudtrail ? var.bucket_arn : aws_s3_bucket.cloudtrail_bucket[0].arn
+  bucket_arn      = var.use_existing_cloudtrail ? trimsuffix(var.bucket_arn, "/") : aws_s3_bucket.cloudtrail_bucket[0].arn
   log_bucket_name = length(var.log_bucket_name) > 0 ? var.log_bucket_name : "${local.bucket_name}-access-logs"
   sns_topic_name  = length(var.sns_topic_name) > 0 ? var.sns_topic_name : "${var.prefix}-sns-${random_id.uniq.hex}"
   sqs_queue_name  = length(var.sqs_queue_name) > 0 ? var.sqs_queue_name : "${var.prefix}-sqs-${random_id.uniq.hex}"


### PR DESCRIPTION
- Added logic to gracefully handle a trailing slash in the `bucket_arn` variable.