### PR TITLE
feat: support for 'mfa_delete' variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Terraform module for configuring an integration with Lacework and AWS for CloudT
 | bucket_arn | The S3 bucket ARN is required only when setting `use_existing_cloudtrail` to true | `string` | "" | no |
 | bucket_enable_encryption | Set this to `true` to enable encryption on a created S3 bucket | `bool` | false | no |
 | bucket_enable_logs | Set this to `true` to enable access logging on a created S3 bucket | `bool` | false | no |
+| bucket_enable_mfa_delete | Set this to `true` to require MFA for object deletion (Requires versioning) | `bool` | true | no |
 | bucket_enable_versioning | Set this to `true` to enable access versioning on a created S3 bucket | `bool` | false | no |
 | bucket_sse_algorithm | Name of the server-side encryption algorithm to use ("AES256" or "aws:kms") | `string` | AES256 | no |
 | bucket_sse_key_arn | The ARN of the KMS encryption key to be used (Required when using "aws:kms") | `string` | "" | no |

--- a/main.tf
+++ b/main.tf
@@ -36,7 +36,8 @@ resource "aws_s3_bucket" "cloudtrail_bucket" {
   policy        = data.aws_iam_policy_document.cloudtrail_s3_policy.json
 
   versioning {
-    enabled = var.bucket_enable_versioning
+    enabled    = var.bucket_enable_versioning
+    mfa_delete = var.bucket_enable_mfa_delete
   }
 
   dynamic "logging" {
@@ -69,7 +70,8 @@ resource "aws_s3_bucket" "cloudtrail_log_bucket" {
   acl           = "log-delivery-write"
 
   versioning {
-    enabled = var.bucket_enable_versioning
+    enabled    = var.bucket_enable_versioning
+    mfa_delete = var.bucket_enable_mfa_delete
   }
 
   dynamic "server_side_encryption_configuration" {

--- a/variables.tf
+++ b/variables.tf
@@ -76,6 +76,12 @@ variable "bucket_enable_logs" {
   description = "Set this to `true` to enable access logging on a created S3 bucket"
 }
 
+variable "bucket_enable_mfa_delete" {
+  type        = bool
+  default     = true
+  description = "Set this to `true` to require MFA for object deletion (Requires versioning)"
+}
+
 variable "bucket_enable_versioning" {
   type        = bool
   default     = false


### PR DESCRIPTION
- Added the ability to toggle 'mfa_delete' for the S3 storage bucket.  This requires versioning to be enabled.