### PR TITLE
docs: Fix link to sns gif

### DIFF
--- a/examples/existing-cloudtrail-without-sns-topic/README.md
+++ b/examples/existing-cloudtrail-without-sns-topic/README.md
@@ -23,7 +23,7 @@ the existing CloudTrail
 SNS delivery notifications manually and point to the generated SNS topic.**
 
 ## Enable SNS delivery notifications manually
-![](../../img/cloudtrail_enable_sns_delivery_notifications.gif)
+![](https://techally-artifacts.s3-us-west-2.amazonaws.com/terraform-module-docs/cloudtrail_enable_sns_delivery_notifications.gif)
 
 ## Enable SNS delivery notifications via Terraform
 


### PR DESCRIPTION
This PR updates the link to the gif for manually attaching SNS topic to existing CloudTrail

Signed-off-by: Scott Ford <scott.ford@lacework.net>