### PR TITLE
feat: allow explicit use of an existing SNS topic

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,15 @@ Terraform module for configuring an integration with Lacework and AWS for CloudT
 | lacework_integration_name | The name of the integration in Lacework. | `string` | TF cloudtrail | no |
 | log_bucket_name | Name of the S3 bucket for access logs | `string` | "" | no |
 | prefix | The prefix that will be use at the beginning of every generated resource | `string` | lacework-ct | no |
+| sns_topic_arn | SNS topic ARN. Can be used when using an existing resource. | `string` | "" | no |
 | sns_topic_name | SNS topic name. Can be used when generating a new resource or when using an existing resource. | `string` | "" | no |
 | sqs_queue_name | SQS queue name. Can be used when generating a new resource or when using an existing resource. | `string` | "" | no |
 | sqs_queues | List of SQS queues to configure in the Lacework cross-account policy. | `list(string)` | `[]` | no |
 | consolidated_trail | Set this to `true` to configure a consolidated cloudtrail. | `bool` | `false` | no |
 | org_account_mappings | Mapping of AWS accounts to Lacework accounts within a Lacework organization. | `list(object)` | `[]` | no |
-| use_existing_cloudtrail | Set this to `true` to use an existing cloudtrail. When set to `true` you must provide both the `bucket_name` and `sns_topic_name` | `bool` | `false` | no |
+| use_existing_cloudtrail | Set this to `true` to use an existing cloudtrail. When set to `true` you must provide the `bucket_name` | `bool` | `false` | no |
 | use_existing_iam_role | Set this to `true` to use an existing IAM role. When set to `true` you must provide both the `iam_role_name` and `iam_role_external_id` | `bool` | `false` | no |
+| use_existing_sns_topic | When using an existing CloudTrail, set this to `true` to use an existing SNS topic. When set to `true` you must provide the `sns_topic_arn` | `bool` | `false` | no |
 | tags | A map/dictionary of Tags to be assigned to created resources. | `map(string)` | `{}` | no |
 | wait_time | Define a custom delay between cloud resource provision and Lacework external integration to avoid errors while things settle down. Use `10s` for 10 seconds, `5m` for 5 minutes. | `string` | `10s` | no |
 

--- a/examples/existing-cloudtrail-iam-role/README.md
+++ b/examples/existing-cloudtrail-iam-role/README.md
@@ -4,15 +4,16 @@ This example integrates an existing CloudTrail and uses an existing IAM Role to 
 
 The following fields are required:
 
-| Name | Description | Type |
-|------|-------------|------|
-| `use_existing_cloudtrail` | Set this to `true` to use an existing CloudTrail. | `bool` |
-| `bucket_name` | The S3 bucket name configured in the existing CloudTrail. | `string` |
-| `bucket_arn` | The S3 bucket ARN configured in the existing CloudTrail. | `string` |
-| `sns_topic_name` | The SNS topic name configured in the existing CloudTrail. | `string` |
-| `use_existing_iam_role` | Set this to `true` to use an existing IAM Role. | `bool` |
-| `iam_role_name` | The existing IAM role name. | `string` |
-| `iam_role_arn` | The existing IAM role ARN. | `string` |
+| Name                      | Description                                               | Type     |
+| ------------------------- | --------------------------------------------------------- | -------- |
+| `use_existing_cloudtrail` | Set this to `true` to use an existing CloudTrail.         | `bool`   |
+| `bucket_arn`              | The S3 bucket ARN configured in the existing CloudTrail.  | `string` |
+| `bucket_name`             | The S3 bucket name configured in the existing CloudTrail. | `string` |
+| `use_existing_sns_topic`  | Set this to `true` to use an existing SNS topic           | `bool`   |
+| `sns_topic_arn`           | The SNS topic ARN configured in the existing CloudTrail.  | `string` |
+| `use_existing_iam_role`   | Set this to `true` to use an existing IAM Role.           | `bool`   |
+| `iam_role_arn`            | The existing IAM role ARN.                                | `string` |
+| `iam_role_name`           | The existing IAM role name.                               | `string` |
 
 ```
 provider "lacework" {}
@@ -27,9 +28,12 @@ module "aws_cloudtrail" {
 
   # Use an existing CloudTrail
   use_existing_cloudtrail = true
-  bucket_arn              = "arn:aws:s3:::lacework-ct-bucket-8805c0bf"
+  bucket_arn              = "arn:aws:s3:::lacework-ct-bucket-7bb591f4"
   bucket_name             = "lacework-ct-bucket-7bb591f4"
-  sns_topic_name          = "lacework-ct-sns-7bb591f4"
+
+  # Use an existing SNS Topic
+  use_existing_sns_topic = true
+  sns_topic_arn          = "arn:aws:sns:us-west-2:123456789012:lacework-ct-sns-7bb591f4"
 
   # Use an existing IAM role
   use_existing_iam_role = true

--- a/examples/existing-cloudtrail-iam-role/main.tf
+++ b/examples/existing-cloudtrail-iam-role/main.tf
@@ -9,9 +9,12 @@ module "aws_cloudtrail" {
 
   # Use an existing CloudTrail
   use_existing_cloudtrail = true
-  bucket_arn              = "arn:aws:s3:::lacework-ct-bucket-8805c0bf"
+  bucket_arn              = "arn:aws:s3:::lacework-ct-bucket-7bb591f4"
   bucket_name             = "lacework-ct-bucket-7bb591f4"
-  sns_topic_name          = "lacework-ct-sns-7bb591f4"
+
+  # Use an existing SNS Topic
+  use_existing_sns_topic = true
+  sns_topic_arn          = "arn:aws:sns:us-west-2:123456789012:lacework-ct-sns-7bb591f4"
 
   # Use an existing IAM role
   use_existing_iam_role = true

--- a/examples/existing-cloudtrail/README.md
+++ b/examples/existing-cloudtrail/README.md
@@ -4,12 +4,13 @@ This example integrates an existing CloudTrail with Lacework and uses an existin
 
 The fields required for this example are:
 
-| Name | Description | Type |
-|------|-------------|------|
-| `use_existing_cloudtrail` | Set this to `true` to use an existing CloudTrail. | `bool` |
-| `bucket_name` | The S3 bucket name configured in the existing CloudTrail. | `string` |
-| `bucket_arn` | The S3 bucket ARN configured in the existing CloudTrail. | `string` |
-| `sns_topic_name` | The SNS topic name configured in the existing CloudTrail. | `string` |
+| Name                      | Description                                               | Type     |
+| ------------------------- | --------------------------------------------------------- | -------- |
+| `use_existing_cloudtrail` | Set this to `true` to use an existing CloudTrail.         | `bool`   |
+| `bucket_arn`              | The S3 bucket ARN configured in the existing CloudTrail.  | `string` |
+| `bucket_name`             | The S3 bucket name configured in the existing CloudTrail. | `string` |
+| `use_existing_sns_topic`  | Set this to `true` to use an existing SNS topic           | `bool`   |
+| `sns_topic_arn`           | The SNS topic ARN configured in the existing CloudTrail.  | `string` |
 
 **IMPORTANT: This example assumes that your CloudTrail is already sending delivery notifications
 to the provided SNS topic. If the existing CloudTrail does NOT have SNS notification enabled,
@@ -30,7 +31,10 @@ module "aws_cloudtrail" {
   use_existing_cloudtrail = true
   bucket_arn              = "arn:aws:s3:::lacework-ct-bucket-8805c0bf"
   bucket_name             = "lacework-ct-bucket-8805c0bf"
-  sns_topic_name          = "lacework-ct-sns-8805c0bf"
+
+  # Use an existing SNS Topic
+  use_existing_sns_topic = true
+  sns_topic_arn          = "arn:aws:sns:us-west-2:713578388890:lacework-ct-sns-8805c0bf"
 }
 ```
 

--- a/examples/existing-cloudtrail/main.tf
+++ b/examples/existing-cloudtrail/main.tf
@@ -11,5 +11,8 @@ module "aws_cloudtrail" {
   use_existing_cloudtrail = true
   bucket_arn              = "arn:aws:s3:::lacework-ct-bucket-8805c0bf"
   bucket_name             = "lacework-ct-bucket-8805c0bf"
-  sns_topic_name          = "lacework-ct-sns-8805c0bf"
+
+  # Use an existing SNS Topic
+  use_existing_sns_topic = true
+  sns_topic_arn          = "arn:aws:sns:us-west-2:123456789012:lacework-ct-sns-8805c0bf"
 }

--- a/examples/existing-encrypted-cloudtrail/README.md
+++ b/examples/existing-encrypted-cloudtrail/README.md
@@ -2,12 +2,13 @@
 
 In this example we let users pass an existing CloudTrail that is encrypted using a KMS key, the fields required for this example are:
 
-| Name | Description | Type |
-|------|-------------|------|
-| `use_existing_cloudtrail` | Set this to `true` to use an existing CloudTrail. | `bool` |
-| `bucket_arn` | The S3 bucket ARN configured in the existing CloudTrail. | `string` |
-| `bucket_enable_encryption` | Set this to `true` to enable encryption on a created S3 bucket | `bool` |
-| `bucket_name` | The S3 bucket name configured in the existing CloudTrail. | `string` |
-| `bucket_sse_algorithm` | Name of the server-side encryption algorithm to use | `string` |
-| `bucket_sse_key_arn` | The ARN of the KMS encryption key to be used | `string` |
-| `sns_topic_name` | The SNS topic name configured in the existing CloudTrail. | `string` |
+| Name                       | Description                                                    | Type     |
+| -------------------------- | -------------------------------------------------------------- | -------- |
+| `use_existing_cloudtrail`  | Set this to `true` to use an existing CloudTrail.              | `bool`   |
+| `bucket_arn`               | The S3 bucket ARN configured in the existing CloudTrail.       | `string` |
+| `bucket_enable_encryption` | Set this to `true` to enable encryption on a created S3 bucket | `bool`   |
+| `bucket_name`              | The S3 bucket name configured in the existing CloudTrail.      | `string` |
+| `bucket_sse_algorithm`     | Name of the server-side encryption algorithm to use            | `string` |
+| `bucket_sse_key_arn`       | The ARN of the KMS encryption key to be used                   | `string` |
+| `use_existing_sns_topic`   | Set this to `true` to use an existing SNS topic                | `bool`   |
+| `sns_topic_arn`            | The SNS topic ARN configured in the existing CloudTrail.       | `string` |

--- a/examples/existing-encrypted-cloudtrail/main.tf
+++ b/examples/existing-encrypted-cloudtrail/main.tf
@@ -14,5 +14,8 @@ module "aws_cloudtrail" {
   bucket_name              = "lacework-ct-bucket-8805c0bf"
   bucket_sse_algorithm     = "aws:kms"
   bucket_sse_key_arn       = "arn:aws:kms:us-east-1:1234567890:key/6e2010aa-27e4-49c6-8887-956abc1caeb9"
-  sns_topic_name           = "lacework-ct-sns-8805c0bf"
+
+  # Use an existing SNS Topic
+  use_existing_sns_topic = true
+  sns_topic_arn          = "arn:aws:sns:us-west-2:123456789012:lacework-ct-sns-8805c0bf"
 }

--- a/output.tf
+++ b/output.tf
@@ -19,8 +19,13 @@ output "sqs_arn" {
 }
 
 output "sns_arn" {
-  value       = aws_sns_topic.lacework_cloudtrail_sns_topic.arn
+  value       = local.sns_topic_arn
   description = "SNS Topic ARN"
+}
+
+output "sns_name" {
+  value       = local.sns_topic_name
+  description = "SNS Topic name"
 }
 
 output "external_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -118,6 +118,12 @@ variable "log_bucket_name" {
   description = "Name of the S3 bucket for access logs"
 }
 
+variable "sns_topic_arn" {
+  type        = string
+  default     = ""
+  description = "The SNS topic ARN"
+}
+
 variable "sns_topic_name" {
   type        = string
   default     = ""
@@ -134,6 +140,12 @@ variable "use_existing_cloudtrail" {
   type        = bool
   default     = false
   description = "Set this to true to use an existing cloudtrail. Default behavior enables new cloudtrail"
+}
+
+variable "use_existing_sns_topic" {
+  type        = bool
+  default     = false
+  description = "Set this to true to use an existing SNS topic. Default behavior creates a new SNS topic"
 }
 
 variable "cloudtrail_name" {


### PR DESCRIPTION
# Switching from SNS Topic Name to SNS Topic ARN

## Previous Configuration Format
```hcl
# Use an existing CloudTrail
use_existing_cloudtrail = true
bucket_arn              = "arn:aws:s3:::lacework-ct-bucket-8805c0bf"
bucket_name             = "lacework-ct-bucket-8805c0bf"
sns_topic_name          = "lacework-ct-sns-8805c0bf"
```

## New Configuration Format
```hcl
# Use an existing CloudTrail
use_existing_cloudtrail = true
bucket_arn              = "arn:aws:s3:::lacework-ct-bucket-8805c0bf"
bucket_name             = "lacework-ct-bucket-8805c0bf"

# Use an existing SNS Topic
use_existing_sns_topic = true
sns_topic_arn          = "arn:aws:sns:us-west-2:123456789012:lacework-ct-sns-8805c0bf"
```

When switching formats to take advantage of the `ARN` rather than an account/region-specific `Name`, the user of this module must remove the Terraform state for the previously imported SNS Topic and SNS Topic Policy - otherwise, Terraform will attempt to delete those resources.  To do this, the following commands will need to be run:

```sh
terraform state rm 'module.<module_name>.aws_sns_topic.lacework_cloudtrail_sns_topic[0]'
terraform state rm 'module.<module_name>.aws_sns_topic_policy.default[0]'
```

Once the state of the SNS Topic and SNS Topic Policy is removed,  and the reference to the existing SNS Topic is changed to ARN as described above, Terraform should show zero pending changes.