### PR TITLE
fix: output reference to local iam_role_name variable

### DIFF
--- a/output.tf
+++ b/output.tf
@@ -34,7 +34,7 @@ output "external_id" {
 }
 
 output "iam_role_name" {
-  value       = var.iam_role_name
+  value       = local.iam_role_name
   description = "The IAM Role name"
 }
 


### PR DESCRIPTION
We were never outputting the actual IAM Role name since we were referencing the variable
defined as `var.iam_role_name` rather than the local variable which has logic to pass the
right variable to the consumer. (that is `local.iam_role_name`)

Closes https://github.com/lacework/terraform-aws-cloudtrail/issues/44

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>