### PR TITLE
docs: Include 'Github' as relevant issue link

### DIFF
--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -3,7 +3,7 @@ name: Pull request template
 about: 'type(scope): Subject of the pull request '
 ---
 
-***Issue***: Include link to the Jira Issue
+***Issue***: Include link to the Jira/Github Issue
 
 ***Description:***
 Provide a detailed description of the changes made by this pull request.


### PR DESCRIPTION
Signed-off-by: Darren Murray <darren.murray@lacework.net>

***Description:***
External contributors will not have access to Jira; include Github as another relevant source for the issue link.

