### PR TITLE
feat: Use existing access log bucket option

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ Terraform module for configuring an integration with Lacework and AWS for CloudT
 |------|-------------|------|---------|:--------:|
 | cloudtrail_name | Name of the CloudTrail | `string` | "lacework-cloudtrail" | no |
 | enable_log_file_validation | Specifies whether CloudTrail log file integrity validation is enabled | `bool` | `false` | no |
-| bucket_force_destroy | Force destroy bucket (Required when bucket not empty) | `bool` | false | no |
+| bucket_force_destroy | Force destroy bucket (Required when bucket not empty) | `bool` | `false` | no |
 | bucket_name | Optional value to specify name for a newly created S3 bucket. Not required when `use_existing_cloudtrail` is true. | `string` | "" | no |
 | bucket_arn | The S3 bucket ARN is required only when setting `use_existing_cloudtrail` to true | `string` | "" | no |
-| bucket_enable_encryption | Set this to `true` to enable encryption on a created S3 bucket | `bool` | false | no |
-| bucket_enable_logs | Set this to `true` to enable access logging on a created S3 bucket | `bool` | false | no |
+| bucket_enable_encryption | Set this to `true` to enable encryption on a created S3 bucket | `bool` | `false` | no |
+| bucket_enable_logs | Set this to `true` to enable access logging on a created S3 bucket | `bool` | `false` | no |
 | bucket_enable_mfa_delete | Set this to `true` to require MFA for object deletion (Requires versioning) | `bool` | `false` | no |
-| bucket_enable_versioning | Set this to `true` to enable access versioning on a created S3 bucket | `bool` | false | no |
+| bucket_enable_versioning | Set this to `true` to enable access versioning on a created S3 bucket | `bool` | `false` | no |
 | bucket_sse_algorithm | Name of the server-side encryption algorithm to use ("AES256" or "aws:kms") | `string` | AES256 | no |
 | bucket_sse_key_arn | The ARN of the KMS encryption key to be used for S3 (Required when `bucket_sse_algorithm` is `aws:kms`) | `string` | "" | no |
 | external_id_length | Length of External ID (max 1224) | `number` | 16 | no |

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ Terraform module for configuring an integration with Lacework and AWS for CloudT
 | iam_role_external_id | External ID for IAM Role | `string` | "" | no |
 | iam_role_name |  The IAM role name | `string` | "lacework_iam_role" | no |
 | lacework_integration_name | The name of the integration in Lacework. | `string` | TF cloudtrail | no |
-| log_bucket_name | Name of the S3 bucket for access logs | `string` | "" | no |
+| log_bucket_name | Name of the S3 bucket for access logs. Is required when setting `use_existing_access_log_bucket` to true | `string` | "" | no |
+| access_log_prefix | Optional value to specify a key prefix for access log objects in logging S3 bucket | `string` | "log/" | no |
 | prefix | The prefix that will be use at the beginning of every generated resource | `string` | lacework-ct | no |
 | sns_topic_arn | SNS topic ARN. Can be used when using an existing resource. | `string` | "" | no |
 | sns_topic_name | SNS topic name. Can be used when generating a new resource or when using an existing resource. | `string` | "" | no |
@@ -37,6 +38,7 @@ Terraform module for configuring an integration with Lacework and AWS for CloudT
 | consolidated_trail | Set this to `true` to configure a consolidated cloudtrail. | `bool` | `false` | no |
 | org_account_mappings | Mapping of AWS accounts to Lacework accounts within a Lacework organization. | `list(object)` | `[]` | no |
 | use_existing_cloudtrail | Set this to `true` to use an existing cloudtrail. When set to `true` you must provide the `bucket_name` | `bool` | `false` | no |
+| use_existing_access_log_bucket | Set this to `true` to use an existing bucket for access logging. When set to `true` you must provide the `access_log_bucket_arn` | `bool` | `false` | no |
 | use_existing_iam_role | Set this to `true` to use an existing IAM role. When set to `true` you must provide both the `iam_role_name` and `iam_role_external_id` | `bool` | `false` | no |
 | use_existing_sns_topic | When using an existing CloudTrail, set this to `true` to use an existing SNS topic. When set to `true` you must provide the `sns_topic_arn` | `bool` | `false` | no |
 | tags | A map/dictionary of Tags to be assigned to created resources. | `map(string)` | `{}` | no |

--- a/main.tf
+++ b/main.tf
@@ -48,8 +48,8 @@ resource "aws_s3_bucket" "cloudtrail_bucket" {
   dynamic "logging" {
     for_each = var.bucket_enable_logs == true ? [1] : []
     content {
-      target_bucket = aws_s3_bucket.cloudtrail_log_bucket[0].id
-      target_prefix = "log/"
+      target_bucket = local.log_bucket_name
+      target_prefix = var.access_log_prefix
     }
   }
 
@@ -69,7 +69,7 @@ resource "aws_s3_bucket" "cloudtrail_bucket" {
 }
 
 resource "aws_s3_bucket" "cloudtrail_log_bucket" {
-  count         = var.use_existing_cloudtrail ? 0 : (var.bucket_enable_logs ? 1 : 0)
+  count         = (var.use_existing_cloudtrail || var.use_existing_access_log_bucket) ? 0 : (var.bucket_enable_logs ? 1 : 0)
   bucket        = local.log_bucket_name
   force_destroy = var.bucket_force_destroy
   acl           = "log-delivery-write"

--- a/variables.tf
+++ b/variables.tf
@@ -115,7 +115,13 @@ variable "bucket_sse_key_arn" {
 variable "log_bucket_name" {
   type        = string
   default     = ""
-  description = "Name of the S3 bucket for access logs"
+  description = "Name of the S3 bucket for access logs. Is required when setting `use_existing_access_log_bucket` to true"
+}
+
+variable "access_log_prefix" {
+  type        = string
+  default     = "log/"
+  description = "Optional value to specify a key prefix for access log objects for logging S3 bucket"
 }
 
 variable "sns_topic_arn" {
@@ -152,6 +158,12 @@ variable "use_existing_cloudtrail" {
   type        = bool
   default     = false
   description = "Set this to true to use an existing cloudtrail. Default behavior enables new cloudtrail"
+}
+
+variable "use_existing_access_log_bucket" {
+  type        = bool
+  default     = false
+  description = "Set this to `true` to use an existing bucket for access logging. Default behavior creates a new access log bucket if logging is enabled"
 }
 
 variable "use_existing_sns_topic" {


### PR DESCRIPTION
---
name: Use existing access log bucket option
about: 'feat(module): Add use of existing access log S3 bucket'
---

***Issue***
https://github.com/lacework/terraform-aws-cloudtrail/issues/56

***Description***
Adding a `use_existing_access_log_bucket` flag which will prevent the default access logs bucket from being created.
Adding an `access_log_prefix` to control logging prefix in said log bucket.

The default logging bucket should only be created if `use_existing_cloudtrail` and `use_existing_access_log_bucket` are both false and if `bucket_enable_logs` is set to true.

To control the selection of the existing log bucket the already created `log_bucket_name` variable will be used. 
The `access_log_prefix` will be defaulted to "logs/" but can be changed.


