### PR TITLE
feat: added support for S3 notification translation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,5 +42,6 @@ override.tf.json
 # vim
 *.swp
 
+/tmp
 /.idea/
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ Terraform module for configuring an integration with Lacework and AWS for CloudT
 | log_bucket_name | Name of the S3 bucket for access logs. Is required when setting `use_existing_access_log_bucket` to true | `string` | "" | no |
 | access_log_prefix | Optional value to specify a key prefix for access log objects in logging S3 bucket | `string` | "log/" | no |
 | prefix | The prefix that will be use at the beginning of every generated resource | `string` | lacework-ct | no |
+| s3_notification_lambda_log_retention | The number of days in which to retain logs for the s3 notification lambda | `number` | `30` | no |
+| s3_notification_lambda_name | The name for the Lambda function used for the S3 notification relay | `string` | `""` | no |
+| s3_notification_role_name | The name for the IAM Role used for the S3 notification relay Lambda function | `string` | `""` | no |
 | sns_topic_arn | SNS topic ARN. Can be used when using an existing resource. | `string` | "" | no |
 | sns_topic_name | SNS topic name. Can be used when generating a new resource or when using an existing resource. | `string` | "" | no |
 | sqs_encryption_enabled | Set this to `true` to enable server-side encryption on SQS. | `bool` | `false` | no |
@@ -41,6 +44,7 @@ Terraform module for configuring an integration with Lacework and AWS for CloudT
 | use_existing_access_log_bucket | Set this to `true` to use an existing bucket for access logging. When set to `true` you must provide the `access_log_bucket_arn` | `bool` | `false` | no |
 | use_existing_iam_role | Set this to `true` to use an existing IAM role. When set to `true` you must provide both the `iam_role_name` and `iam_role_external_id` | `bool` | `false` | no |
 | use_existing_sns_topic | When using an existing CloudTrail, set this to `true` to use an existing SNS topic. When set to `true` you must provide the `sns_topic_arn` | `bool` | `false` | no |
+| use_s3_notification_relay | Set this to `true` to translate S3 bucket notifications for Lacework consumption | `bool` | `false` | no |
 | tags | A map/dictionary of Tags to be assigned to created resources. | `map(string)` | `{}` | no |
 | wait_time | Define a custom delay between cloud resource provision and Lacework external integration to avoid errors while things settle down. Use `10s` for 10 seconds, `5m` for 5 minutes. | `string` | `10s` | no |
 

--- a/examples/existing-cloudtrail-s3-notifications/README.md
+++ b/examples/existing-cloudtrail-s3-notifications/README.md
@@ -1,0 +1,35 @@
+# Integrate Existing CloudTrail with Lacework using S3 Bucket Notifications
+
+This example integrates an existing CloudTrail with Lacework and uses S3 Bucket Notifications for updates
+
+## Inputs
+
+| Name                        | Description                                                                      | Type     |
+| --------------------------- | -------------------------------------------------------------------------------- | -------- |
+| `use_existing_cloudtrail`   | Set this to `true` to use an existing CloudTrail.                                | `bool`   |
+| `bucket_arn`                | The S3 bucket ARN configured in the existing CloudTrail.                         | `string` |
+| `use_s3_notification_relay` | Set this to `true` to translate S3 bucket notifications for Lacework consumption | `bool`   |
+
+## Sample Code
+
+```hcl
+provider "lacework" {}
+
+provider "aws" {
+  region = "us-west-2"
+}
+
+module "aws_cloudtrail" {
+  source  = "lacework/cloudtrail/aws"
+  version = "~> 0.1"
+
+  # Use an existing CloudTrail
+  use_existing_cloudtrail = true
+  bucket_arn              = "arn:aws:s3:::lacework-ct-bucket-8805c0bf"
+
+  # Use S3 notifications, rather than CloudTrail notifications
+  use_s3_notification_relay = true
+}
+```
+
+For detailed information on integrating Lacework with AWS see [AWS Config and CloudTrail Integration with Terraform](https://support.lacework.com/hc/en-us/articles/360057092034-AWS-Config-and-CloudTrail-Integration-with-Terraform)

--- a/examples/existing-cloudtrail-s3-notifications/main.tf
+++ b/examples/existing-cloudtrail-s3-notifications/main.tf
@@ -1,0 +1,16 @@
+provider "lacework" {}
+
+provider "aws" {
+  region = "us-west-2"
+}
+
+module "aws_cloudtrail" {
+  source = "../../"
+
+  # Use an existing CloudTrail
+  use_existing_cloudtrail = true
+  bucket_arn              = "arn:aws:s3:::lacework-ct-bucket-8805c0bf"
+
+  # Use S3 notifications, rather than CloudTrail notifications
+  use_s3_notification_relay = true
+}

--- a/examples/existing-cloudtrail-s3-notifications/versions.tf
+++ b/examples/existing-cloudtrail-s3-notifications/versions.tf
@@ -1,0 +1,8 @@
+# required for Terraform 13
+terraform {
+  required_providers {
+    lacework = {
+      source = "lacework/lacework"
+    }
+  }
+}

--- a/functions/source/s3-notification-relay/main.py
+++ b/functions/source/s3-notification-relay/main.py
@@ -1,0 +1,29 @@
+import json
+import os
+
+import boto3
+
+sns_client = boto3.client("sns")
+TARGET_ARN = os.getenv("SNS_TOPIC_ARN")
+
+
+def publisher(msg):
+    sns_client.publish(
+        TargetArn=TARGET_ARN,
+        Message=json.dumps({"default": json.dumps(msg)}),
+        Subject='Cloudtrail event from bucket',
+        MessageStructure='json',
+    )
+
+
+def get_record_object_key(record):
+    return record["s3"]["object"]["key"]
+
+
+def handler(event, context):
+    records = event["Records"]
+    cloudtrail_notification = {
+        "s3Bucket": records[0]["s3"]["bucket"]["name"],
+        "s3ObjectKey": [get_record_object_key(record) for record in records]
+    }
+    publisher(cloudtrail_notification)

--- a/scripts/ci_tests.sh
+++ b/scripts/ci_tests.sh
@@ -16,6 +16,7 @@ TEST_CASES=(
   examples/consolidated-cloudtrail
   examples/existing-cloudtrail-end-to-end-encryption
   examples/existing-cloudtrail-s3-encryption
+  examples/existing-cloudtrail-s3-notifications
   examples/existing-cloudtrail-iam-role
   examples/existing-cloudtrail
   examples/existing-cloudtrail-without-sns-topic

--- a/variables.tf
+++ b/variables.tf
@@ -172,6 +172,30 @@ variable "use_existing_sns_topic" {
   description = "Set this to true to use an existing SNS topic. Default behavior creates a new SNS topic"
 }
 
+variable "s3_notification_lambda_name" {
+  type        = string
+  default     = ""
+  description = "The name for the Lambda function used for the S3 notification relay"
+}
+
+variable "s3_notification_lambda_log_retention" {
+  type        = number
+  default     = 30
+  description = "The number of days in which to retain logs for the s3 notification lambda"
+}
+
+variable "s3_notification_role_name" {
+  type        = string
+  default     = ""
+  description = "The name for the IAM Role used for the S3 notification relay Lambda function"
+}
+
+variable "use_s3_notification_relay" {
+  type        = bool
+  default     = false
+  description = "Set this to `true` to translate S3 bucket notifications for Lacework consumption"
+}
+
 variable "cloudtrail_name" {
   type        = string
   default     = "lacework-cloudtrail"


### PR DESCRIPTION
---
name: Adding support for S3 Bucket Notifications via Lambda Function translation
about: 'feat: added support for S3 notification translation'
---

***Issue***: https://github.com/lacework/terraform-aws-cloudtrail/issues/50

***Description:***
In some cases, an organization may configure individual CloudTrail "trails" for each of their AWS accounts, while at the same time sending the CloudTrail logs to a centralized bucket.  In this architecture, if CloudTrail hasn't been previously configured to send notifications to a centralized SNS Topic, it can be burdensome to implement Lacework as each trail would need to be updated individually.

This PR takes advantage of S3 bucket notifications by converting the S3 notification into the CloudTrail notification format, and then publishing the data to the created SNS Topic.  This conversion takes place via Lambda.

***Additional Info:***
The S3 notification is a superset of CloudTrail notification data.

S3: 
```
{  
   "Records":[  
      {  
         "eventVersion":"2.2",
         "eventSource":"aws:s3",
         "awsRegion":"us-west-2",
         "eventTime":"The time, in ISO-8601 format, for example, 1970-01-01T00:00:00.000Z, when Amazon S3 finished processing the request",
         "eventName":"event-type",
         "userIdentity":{  
            "principalId":"Amazon-customer-ID-of-the-user-who-caused-the-event"
         },
         "requestParameters":{  
            "sourceIPAddress":"ip-address-where-request-came-from"
         },
         "responseElements":{  
            "x-amz-request-id":"Amazon S3 generated request ID",
            "x-amz-id-2":"Amazon S3 host that processed the request"
         },
         "s3":{  
            "s3SchemaVersion":"1.0",
            "configurationId":"ID found in the bucket notification configuration",
            "bucket":{  
               "name":"bucket-name",
               "ownerIdentity":{  
                  "principalId":"Amazon-customer-ID-of-the-bucket-owner"
               },
               "arn":"bucket-ARN"
            },
            "object":{  
               "key":"object-key",
               "size":"object-size in bytes",
               "eTag":"object eTag",
               "versionId":"object version if bucket is versioning-enabled, otherwise null",
               "sequencer": "a string representation of a hexadecimal value used to determine event sequence, only used with PUTs and DELETEs"
            }
         },
         "glacierEventData": {
            "restoreEventData": {
               "lifecycleRestorationExpiryTime": "The time, in ISO-8601 format, for example, 1970-01-01T00:00:00.000Z, of Restore Expiry",
               "lifecycleRestoreStorageClass": "Source storage class for restore"
            }
         }
      }
   ]
}
```

CloudTrail:
```
{
    "s3Bucket": "your-bucket-name",
    "s3ObjectKey": [
        "AWSLogs/123456789012/CloudTrail/us-east-2/2016/08/11/123456789012_CloudTrail_us-east-2_20160811T2215Z_kpaMYavMQA9Ahp7L.json.gz",
        "AWSLogs/123456789012/CloudTrail/us-east-2/2016/08/11/123456789012_CloudTrail_us-east-2_20160811T2210Z_zqDkyQv3TK8ZdLr0.json.gz",
        "AWSLogs/123456789012/CloudTrail/us-east-2/2016/08/11/123456789012_CloudTrail_us-east-2_20160811T2205Z_jaMVRa6JfdLCJYHP.json.gz"
    ]
}
```