### PR TITLE
feat: ensure resources adhere to Lacework compliance rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,17 @@ Terraform module for configuring an integration with Lacework and AWS for CloudT
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | cloudtrail_name | Name of the CloudTrail | `string` | "lacework-cloudtrail" | no |
-| enable_log_file_validation | Specifies whether CloudTrail log file integrity validation is enabled | `bool` | `false` | no |
+| enable_log_file_validation | Specifies whether CloudTrail log file integrity validation is enabled | `bool` | `true` | no |
 | bucket_force_destroy | Force destroy bucket (Required when bucket not empty) | `bool` | `false` | no |
 | bucket_name | Optional value to specify name for a newly created S3 bucket. Not required when `use_existing_cloudtrail` is true. | `string` | "" | no |
 | bucket_arn | The S3 bucket ARN is required only when setting `use_existing_cloudtrail` to true | `string` | "" | no |
-| bucket_enable_encryption | Set this to `true` to enable encryption on a created S3 bucket | `bool` | `false` | no |
-| bucket_enable_logs | Set this to `true` to enable access logging on a created S3 bucket | `bool` | `false` | no |
+| bucket_encryption_enabled | (deprecated) Use `bucket_enable_encryption` instead  | `bool` | `false` | no |
+| bucket_enable_encryption | Set this to `true` to enable encryption on a created S3 bucket | `bool` | `true` | no |
+| bucket_enable_logs | (deprecated) Use `bucket_logs_enabled` instead | `bool` | `false` | no |
+| bucket_logs_enabled | Set this to `true` to enable access logging on a created S3 bucket | `bool` | `true` | no |
 | bucket_enable_mfa_delete | Set this to `true` to require MFA for object deletion (Requires versioning) | `bool` | `false` | no |
-| bucket_enable_versioning | Set this to `true` to enable access versioning on a created S3 bucket | `bool` | `false` | no |
+| bucket_enable_versioning | (deprecated) Use `bucket_versioning_enabled` instead | `bool` | `false` | no |
+| bucket_versioning_enabled | Set this to `true` to enable access versioning on a created S3 bucket | `bool` | `true` | no |
 | bucket_sse_algorithm | Name of the server-side encryption algorithm to use ("AES256" or "aws:kms") | `string` | AES256 | no |
 | bucket_sse_key_arn | The ARN of the KMS encryption key to be used for S3 (Required when `bucket_sse_algorithm` is `aws:kms`) | `string` | "" | no |
 | external_id_length | Length of External ID (max 1224) | `number` | 16 | no |

--- a/examples/complete-cloudtrail/main.tf
+++ b/examples/complete-cloudtrail/main.tf
@@ -7,9 +7,7 @@ provider "lacework" {}
 module "aws_cloudtrail" {
   source = "../../"
 
-  enable_log_file_validation = true
-  bucket_force_destroy       = true
-  bucket_enable_encryption   = true
-  bucket_enable_logs         = true
-  bucket_enable_versioning   = true
+  kms_key_deletion_days = 30
+  bucket_force_destroy  = true
+
 }

--- a/variables.tf
+++ b/variables.tf
@@ -54,7 +54,7 @@ variable "prefix" {
 
 variable "enable_log_file_validation" {
   type        = bool
-  default     = false
+  default     = true
   description = "Specifies whether cloudtrail log file integrity validation is enabled"
 }
 
@@ -72,13 +72,25 @@ variable "bucket_arn" {
 
 variable "bucket_enable_encryption" {
   type        = bool
-  default     = false
+  default     = true
+  description = "(deprecated) Use `bucket_encryption_enabled` instead"
+}
+
+variable "bucket_encryption_enabled" {
+  type        = bool
+  default     = true
   description = "Set this to `true` to enable encryption on a created S3 bucket"
 }
 
 variable "bucket_enable_logs" {
   type        = bool
-  default     = false
+  default     = true
+  description = "(deprecated) Use `bucket_logs_enabled` instead"
+}
+
+variable "bucket_logs_enabled" {
+  type        = bool
+  default     = true
   description = "Set this to `true` to enable access logging on a created S3 bucket"
 }
 
@@ -90,7 +102,13 @@ variable "bucket_enable_mfa_delete" {
 
 variable "bucket_enable_versioning" {
   type        = bool
-  default     = false
+  default     = true
+  description = "(deprecated) Use `bucket_versioning_enabled` instead"
+}
+
+variable "bucket_versioning_enabled" {
+  type        = bool
+  default     = true
   description = "Set this to `true` to enable access versioning on a created S3 bucket"
 }
 
@@ -102,14 +120,14 @@ variable "bucket_force_destroy" {
 
 variable "bucket_sse_algorithm" {
   type        = string
-  default     = "AES256"
+  default     = "aws:kms"
   description = "The encryption algorithm to use for S3 bucket server-side encryption"
 }
 
 variable "bucket_sse_key_arn" {
   type        = string
   default     = ""
-  description = "The ARN of the KMS encryption key to be used for S3 (Required when `bucket_sse_algorithm` is `aws:kms`)"
+  description = "The ARN of the KMS encryption key to be used for S3 (Required when `bucket_sse_algorithm` is `aws:kms` and using an existing aws_kms_key)"
 }
 
 variable "log_bucket_name" {
@@ -211,4 +229,16 @@ variable "tags" {
   type        = map(string)
   description = "A map/dictionary of Tags to be assigned to created resources"
   default     = {}
+}
+
+variable "kms_key_deletion_days" {
+  type        = number
+  default     = 30
+  description = "The waiting period, specified in number of days"
+}
+
+variable "kms_key_multi_region" {
+  type        = bool
+  default     = true
+  description = "Whether the KMS key is a multi-region or regional key"
 }


### PR DESCRIPTION
This change requires major version bump

***Issue***:  https://lacework.atlassian.net/browse/ALLY-740

***Description:***
Variable defaults should not violate compliance rules


Changes to default settings
```
`enable_log_file_validation`: true
`bucket_enable_logs`: true
`bucket_enable_versioning`: true
`bucket_enable_encryption`: true
```

Todo update documentation for `bucket_enable_mfa_delete` -> detail that compliance will fail LW_S3_12 unless enabled

