### PR TITLE
fix: aws required_provider version constraint

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.31"
 
   required_providers {
-    aws    = "~> 3.0"
+    aws    = "~> 3.64"
     random = ">= 2.1"
     time   = "~> 0.6"
     lacework = {


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary

The `multi_region` attribute in the KMS key was created in version
3.64.0, we should pin the version of the aws provider to be major than
that version.

https://github.com/hashicorp/terraform-provider-aws/pull/20533


Signed-off-by: Salim Afiune Maya <afiune@lacework.net>

## How did you test this change?

Verified the version of the aws provider that has the new functionality, replicated the issue
locally and with this fix, the module works as expected.

## Issue
https://lacework.atlassian.net/browse/ALLY-912
Closes https://github.com/lacework/terraform-aws-cloudtrail/issues/73

