### PR TITLE
feat: allow Lacework integration creation to be optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Terraform module for configuring an integration with Lacework and AWS for CloudT
 | <a name="input_bucket_versioning_enabled"></a> [bucket\_versioning\_enabled](#input\_bucket\_versioning\_enabled) | Set this to `true` to enable access versioning on a created S3 bucket | `bool` | `true` | no |
 | <a name="input_cloudtrail_name"></a> [cloudtrail\_name](#input\_cloudtrail\_name) | The name of the CloudTrail | `string` | `"lacework-cloudtrail"` | no |
 | <a name="input_consolidated_trail"></a> [consolidated\_trail](#input\_consolidated\_trail) | Set this to true to configure a consolidated cloudtrail | `bool` | `false` | no |
+| <a name="input_create_lacework_integration"></a> [create\_lacework\_integration](#input\_create\_lacework\_integration) | Set this to `false` if you don't want the module to automatically create a corresponding Lacework integration. | `bool` | `true` | no |
 | <a name="input_cross_account_policy_name"></a> [cross\_account\_policy\_name](#input\_cross\_account\_policy\_name) | n/a | `string` | `""` | no |
 | <a name="input_enable_log_file_validation"></a> [enable\_log\_file\_validation](#input\_enable\_log\_file\_validation) | Specifies whether cloudtrail log file integrity validation is enabled | `bool` | `true` | no |
 | <a name="input_external_id_length"></a> [external\_id\_length](#input\_external\_id\_length) | The length of the external ID to generate. Max length is 1224. Ignored when use\_existing\_iam\_role is set to true | `number` | `16` | no |
@@ -128,3 +129,4 @@ Terraform module for configuring an integration with Lacework and AWS for CloudT
 | <a name="output_sns_name"></a> [sns\_name](#output\_sns\_name) | SNS Topic name |
 | <a name="output_sqs_arn"></a> [sqs\_arn](#output\_sqs\_arn) | SQS Queue ARN |
 | <a name="output_sqs_name"></a> [sqs\_name](#output\_sqs\_name) | SQS Queue name |
+| <a name="output_sqs_url"></a> [sqs\_url](#output\_sqs\_url) | SQS Queue URL |

--- a/main.tf
+++ b/main.tf
@@ -28,6 +28,7 @@ locals {
   iam_role_name = var.use_existing_iam_role ? var.iam_role_name : (
     length(var.iam_role_name) > 0 ? var.iam_role_name : "${var.prefix}-iam-${random_id.uniq.hex}"
   )
+  lacework_integration_guid = var.create_lacework_integration && length(var.sqs_queues) == 0 ? lacework_integration_aws_ct.default[0].id : ""
   mfa_delete                = var.bucket_versioning_enabled && var.bucket_enable_mfa_delete ? "Enabled" : "Disabled"
   bucket_encryption_enabled = var.bucket_encryption_enabled && length(local.bucket_sse_key_arn) > 0
   bucket_versioning_enabled = var.bucket_versioning_enabled ? "Enabled" : "Suspended"
@@ -551,7 +552,7 @@ resource "lacework_integration_aws_ct" "default" {
   // do not create a CT integration if the user provides multiple
   // SQS queues to configure, it means that they want to fan-out
   // with a lambda function that acks like a gateway
-  count     = length(var.sqs_queues) > 0 ? 0 : 1
+  count     = var.create_lacework_integration && length(var.sqs_queues) == 0 ? 1 : 0
   name      = var.lacework_integration_name
   queue_url = aws_sqs_queue.lacework_cloudtrail_sqs_queue.id
   credentials {

--- a/output.tf
+++ b/output.tf
@@ -18,6 +18,11 @@ output "sqs_arn" {
   description = "SQS Queue ARN"
 }
 
+output "sqs_url" {
+  value       = aws_sqs_queue.lacework_cloudtrail_sqs_queue.url
+  description = "SQS Queue URL"
+}
+
 output "sns_arn" {
   value       = local.sns_topic_arn
   description = "SNS Topic ARN"
@@ -44,6 +49,6 @@ output "iam_role_arn" {
 }
 
 output "lacework_integration_guid" {
-  value       = lacework_integration_aws_ct.default[0].id
+  value       = local.lacework_integration_guid
   description = "Lacework CloudTrail Integration GUID"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,9 @@
+variable "create_lacework_integration" {
+  type        = bool
+  default     = true
+  description = "Set this to `false` if you don't want the module to automatically create a corresponding Lacework integration."
+}
+
 variable "consolidated_trail" {
   type        = bool
   default     = false


### PR DESCRIPTION
## Summary

This PR allows the creation of the CloudTrail integration in Lacework to be optional, and provides all required parameters as outputs in the module.  This is done to allow extensibility in how the integration is created.

## How did you test this change?

Tested this change in my AWS organization.

## Issue

N/A

