### PR TITLE
fix: handle use_existing_access_log_bucket correctly in aws_s3_bucket_logging resource

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -73,7 +73,7 @@ resource "aws_s3_bucket" "cloudtrail_bucket" {
 resource "aws_s3_bucket_logging" "cloudtrail_bucket_logging" {
   count         = var.bucket_logs_enabled && !var.use_existing_cloudtrail ? 1 : 0
   bucket        = aws_s3_bucket.cloudtrail_bucket[0].id
-  target_bucket = aws_s3_bucket.cloudtrail_log_bucket[0].id
+  target_bucket = var.use_existing_access_log_bucket ? local.log_bucket_name : aws_s3_bucket.cloudtrail_log_bucket[0].id
   target_prefix = var.access_log_prefix
 }
 


### PR DESCRIPTION


## Summary

The variable `use_existing_access_log_bucket` was not being handled correctly in `aws_s3_bucket_logging` resource

If variable `use_existing_access_log_bucket` is true set target_bucket to use local variable else use newly created bucket

## How did you test this change?

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

## Issue

https://lacework.atlassian.net/browse/ALLY-1291

