### PR TITLE
feat: add permissions_boundary variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -528,6 +528,7 @@ module "lacework_ct_iam_role" {
   version                 = "~> 0.1"
   create                  = var.use_existing_iam_role ? false : true
   iam_role_name           = local.iam_role_name
+  permissions_boundary    = var.permission_boundary_arn
   lacework_aws_account_id = var.lacework_aws_account_id
   external_id_length      = var.external_id_length
   tags                    = var.tags

--- a/main.tf
+++ b/main.tf
@@ -525,7 +525,7 @@ resource "aws_iam_policy" "cross_account_policy" {
 
 module "lacework_ct_iam_role" {
   source                  = "lacework/iam-role/aws"
-  version                 = "~> 0.1"
+  version                 = "~> 0.3"
   create                  = var.use_existing_iam_role ? false : true
   iam_role_name           = local.iam_role_name
   permissions_boundary    = var.permission_boundary_arn

--- a/variables.tf
+++ b/variables.tf
@@ -58,6 +58,12 @@ variable "iam_role_external_id" {
   description = "The external ID configured inside the IAM role is required when setting use_existing_iam_role to true"
 }
 
+variable "permission_boundary_arn" {
+  type        = string
+  default     = null
+  description = "Optional - ARN of the policy that is used to set the permissions boundary for the role."
+}
+
 variable "external_id_length" {
   type        = number
   default     = 16


### PR DESCRIPTION
Allows to implement a set of boundaries to the role created by Lacework

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary

<!--
Adding Permissions Boundary variable to provide the ability to enforce external permissions rights for the Lacework created role. Requires an already existing permissions boundary. Applying without careful consideration can forbid access to Lacework.
-->

## How did you test this change?

<!--
-->


