### PR TITLE
feat(client): Filter SNS messages events

### DIFF
--- a/examples/existing-cloudtrail-s3-notifications-with-filter/README.md
+++ b/examples/existing-cloudtrail-s3-notifications-with-filter/README.md
@@ -1,0 +1,56 @@
+# Integrate Existing CloudTrail using S3 Bucket notifications
+
+This example integrates an existing CloudTrail with Lacework and uses S3 Bucket notifications, rather than CloudTrail SNS notifications.
+
+## Inputs
+
+| Name                         | Description                                                                | Type     |
+| ---------------------------- | -------------------------------------------------------------------------- | -------- |
+| `use_existing_cloudtrail`    | Set this to `true` to use an existing CloudTrail.                          | `bool`   |
+| `bucket_arn`                 | The S3 bucket ARN configured in the existing CloudTrail.                   | `string` |
+| `use_s3_bucket_notification` | Set this to `true` to use S3 bucket notifications, rather than CloudTrail. | `bool`   |
+
+## Sample Code
+
+```hcl
+provider "lacework" {}
+
+provider "aws" {
+  region = "us-west-2"
+}
+
+locals {
+  accountids_with_lacework_enabled = [
+    "111111111111",
+  ]
+}
+
+module "aws_cloudtrail" {
+  source = "../../"
+
+  # Use an existing CloudTrail
+  use_existing_cloudtrail = true
+  bucket_arn              = "arn:aws:s3:::lacework-ct-bucket-8805c0bf"
+
+  # Use S3 Bucket Notifications
+  use_s3_bucket_notification = true
+  s3_notification_type       = "SNS"
+  sns_topic_filter_policy = jsonencode({
+    # SNS filtering https://docs.aws.amazon.com/sns/latest/dg/sns-message-filtering.html
+    # SNS event example https://docs.aws.amazon.com/awscloudtrail/latest/userguide/configure-sns-notifications-for-cloudtrail.html
+    # S3 cloudtrail path format https://docs.aws.amazon.com/AmazonS3/latest/userguide/cloudtrail-request-identification.html
+    s3ObjectKey = {
+      Type = "String.Array"
+      Value = [
+        for accountid in local.accountids_with_lacework_enabled :
+        {
+          prefix = "AWSLogs/${accountid}/"
+        }
+      ]
+    }
+  })
+  sns_topic_filter_policy_scope = "MessageBody"
+}
+```
+
+For detailed information on integrating Lacework with AWS see [AWS Config and CloudTrail Integration with Terraform](https://support.lacework.com/hc/en-us/articles/360057092034-AWS-Config-and-CloudTrail-Integration-with-Terraform)

--- a/examples/existing-cloudtrail-s3-notifications-with-filter/README.md
+++ b/examples/existing-cloudtrail-s3-notifications-with-filter/README.md
@@ -33,23 +33,20 @@ module "aws_cloudtrail" {
   bucket_arn              = "arn:aws:s3:::lacework-ct-bucket-8805c0bf"
 
   # Use S3 Bucket Notifications
-  use_s3_bucket_notification = true
-  s3_notification_type       = "SNS"
+  use_s3_bucket_notification    = true
+  s3_notification_type          = "SNS"
+  sns_topic_filter_policy_scope = "MessageBody"
   sns_topic_filter_policy = jsonencode({
     # SNS filtering https://docs.aws.amazon.com/sns/latest/dg/sns-message-filtering.html
     # SNS event example https://docs.aws.amazon.com/awscloudtrail/latest/userguide/configure-sns-notifications-for-cloudtrail.html
     # S3 cloudtrail path format https://docs.aws.amazon.com/AmazonS3/latest/userguide/cloudtrail-request-identification.html
-    s3ObjectKey = {
-      Type = "String.Array"
-      Value = [
-        for accountid in local.accountids_with_lacework_enabled :
-        {
-          prefix = "AWSLogs/${accountid}/"
-        }
-      ]
-    }
+    s3ObjectKey = [
+      for accountid in local.accountids_with_lacework_enabled :
+      {
+        prefix = "AWSLogs/${accountid}/"
+      }
+    ]
   })
-  sns_topic_filter_policy_scope = "MessageBody"
 }
 ```
 

--- a/examples/existing-cloudtrail-s3-notifications-with-filter/main.tf
+++ b/examples/existing-cloudtrail-s3-notifications-with-filter/main.tf
@@ -18,21 +18,18 @@ module "aws_cloudtrail" {
   bucket_arn              = "arn:aws:s3:::lacework-ct-bucket-8805c0bf"
 
   # Use S3 Bucket Notifications
-  use_s3_bucket_notification = true
-  s3_notification_type       = "SNS"
+  use_s3_bucket_notification    = true
+  s3_notification_type          = "SNS"
+  sns_topic_filter_policy_scope = "MessageBody"
   sns_topic_filter_policy = jsonencode({
     # SNS filtering https://docs.aws.amazon.com/sns/latest/dg/sns-message-filtering.html
     # SNS event example https://docs.aws.amazon.com/awscloudtrail/latest/userguide/configure-sns-notifications-for-cloudtrail.html
     # S3 cloudtrail path format https://docs.aws.amazon.com/AmazonS3/latest/userguide/cloudtrail-request-identification.html
-    s3ObjectKey = {
-      Type = "String.Array"
-      Value = [
-        for accountid in local.accountids_with_lacework_enabled :
-        {
-          prefix = "AWSLogs/${accountid}/"
-        }
-      ]
-    }
+    s3ObjectKey = [
+      for accountid in local.accountids_with_lacework_enabled :
+      {
+        prefix = "AWSLogs/${accountid}/"
+      }
+    ]
   })
-  sns_topic_filter_policy_scope = "MessageBody"
 }

--- a/examples/existing-cloudtrail-s3-notifications-with-filter/main.tf
+++ b/examples/existing-cloudtrail-s3-notifications-with-filter/main.tf
@@ -1,0 +1,38 @@
+provider "lacework" {}
+
+provider "aws" {
+  region = "us-west-2"
+}
+
+locals {
+  accountids_with_lacework_enabled = [
+    "111111111111",
+  ]
+}
+
+module "aws_cloudtrail" {
+  source = "../../"
+
+  # Use an existing CloudTrail
+  use_existing_cloudtrail = true
+  bucket_arn              = "arn:aws:s3:::lacework-ct-bucket-8805c0bf"
+
+  # Use S3 Bucket Notifications
+  use_s3_bucket_notification = true
+  s3_notification_type       = "SNS"
+  sns_topic_filter_policy = jsonencode({
+    # SNS filtering https://docs.aws.amazon.com/sns/latest/dg/sns-message-filtering.html
+    # SNS event example https://docs.aws.amazon.com/awscloudtrail/latest/userguide/configure-sns-notifications-for-cloudtrail.html
+    # S3 cloudtrail path format https://docs.aws.amazon.com/AmazonS3/latest/userguide/cloudtrail-request-identification.html
+    s3ObjectKey = {
+      Type = "String.Array"
+      Value = [
+        for accountid in local.accountids_with_lacework_enabled :
+        {
+          prefix = "AWSLogs/${accountid}/"
+        }
+      ]
+    }
+  })
+  sns_topic_filter_policy_scope = "MessageBody"
+}

--- a/examples/existing-cloudtrail-s3-notifications-with-filter/versions.tf
+++ b/examples/existing-cloudtrail-s3-notifications-with-filter/versions.tf
@@ -1,0 +1,8 @@
+# required for Terraform 13
+terraform {
+  required_providers {
+    lacework = {
+      source = "lacework/lacework"
+    }
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -430,10 +430,12 @@ POLICY
 }
 
 resource "aws_sns_topic_subscription" "lacework_sns_topic_sub" {
-  count     = (var.use_s3_bucket_notification && var.s3_notification_type == "SQS") ? 0 : 1
-  topic_arn = local.sns_topic_arn
-  protocol  = "sqs"
-  endpoint  = aws_sqs_queue.lacework_cloudtrail_sqs_queue.arn
+  count               = (var.use_s3_bucket_notification && var.s3_notification_type == "SQS") ? 0 : 1
+  topic_arn           = local.sns_topic_arn
+  protocol            = "sqs"
+  endpoint            = aws_sqs_queue.lacework_cloudtrail_sqs_queue.arn
+  filter_policy       = var.sns_topic_filter_policy
+  filter_policy_scope = var.sns_topic_filter_policy_scope
 }
 
 data "aws_iam_policy_document" "cross_account_policy" {

--- a/variables.tf
+++ b/variables.tf
@@ -185,18 +185,13 @@ variable "sns_topic_encryption_enabled" {
 
 variable "sns_topic_filter_policy_scope" {
   type        = string
-  default     = "MessageBody"
+  default     = null
   description = "Whether the filter_policy applies to 'MessageAttributes' or 'MessageBody'."
-
-  validation {
-    condition     = contains(["MessageAttributes", "MessageBody"], var.sns_topic_filter_policy_scope)
-    error_message = "Valid values for variable 'sns_topic_filter_policy_scope' are: ['MessageAttributes', 'MessageBody']."
-  }
 }
 
 variable "sns_topic_filter_policy" {
   type        = string
-  default     = ""
+  default     = null
   description = "JSON String with the filter policy that will be used in the subscription to filter messages seen by the target resource. Refer to the [SNS docs](https://docs.aws.amazon.com/sns/latest/dg/message-filtering.html) for more details."
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -183,6 +183,23 @@ variable "sns_topic_encryption_enabled" {
   description = "Set this to `false` to disable encryption on a sns topic. Defaults to true"
 }
 
+variable "sns_topic_filter_policy_scope" {
+  type        = string
+  default     = "MessageBody"
+  description = "Whether the filter_policy applies to 'MessageAttributes' or 'MessageBody'."
+
+  validation {
+    condition     = contains(["MessageAttributes", "MessageBody"], var.sns_topic_filter_policy_scope)
+    error_message = "Valid values for variable 'sns_topic_filter_policy_scope' are: ['MessageAttributes', 'MessageBody']."
+  }
+}
+
+variable "sns_topic_filter_policy" {
+  type        = string
+  default     = ""
+  description = "JSON String with the filter policy that will be used in the subscription to filter messages seen by the target resource. Refer to the [SNS docs](https://docs.aws.amazon.com/sns/latest/dg/message-filtering.html) for more details."
+}
+
 variable "sqs_queue_name" {
   type        = string
   default     = ""

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.14"
 
   required_providers {
-    aws    = "~> 4.0"
+    aws    = "~> 4.0, >= 4.42.0"
     random = ">= 2.1"
     time   = "~> 0.6"
     lacework = {


### PR DESCRIPTION
## Summary

Allows filtering SNS messages, in my case per account ID so only the necessary Cloudtrail events are evaluated on Lacework

## How did you test this change?

This change is running in our infrastructure that is connected to Lacework

## Issue

- #101 
