### PR TITLE
fix: use valid module argument permission_boundary_arn

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -528,7 +528,7 @@ module "lacework_ct_iam_role" {
   version                 = "~> 0.3"
   create                  = var.use_existing_iam_role ? false : true
   iam_role_name           = local.iam_role_name
-  permissions_boundary    = var.permission_boundary_arn
+  permission_boundary_arn = var.permission_boundary_arn
   lacework_aws_account_id = var.lacework_aws_account_id
   external_id_length      = var.external_id_length
   tags                    = var.tags


### PR DESCRIPTION

## Summary

<img src="https://media3.giphy.com/media/3xz2BLBOt13X9AgjEA/giphy.gif"/>

## How did you test this change?
CI should pass! 🤞🏽 

## Issue

Fixes https://github.com/lacework/terraform-aws-cloudtrail/pull/103