### PR TITLE
fix: SNS policy to match attachment update

### DIFF
--- a/examples/existing-cloudtrail-without-sns-topic/README.md
+++ b/examples/existing-cloudtrail-without-sns-topic/README.md
@@ -7,12 +7,15 @@ the example named [existing-cloudtrail](https://registry.terraform.io/modules/la
 
 **IMPORTANT:** The new SNS topic must be created in the same region as the existing CloudTrail.
 
+**IMPORTANT:** The existing `cloudtrail_name` is required for the SNS Topic policy.
+
 ## Inputs
 
 | Name                      | Description                                               | Type     |
 | ------------------------- | --------------------------------------------------------- | -------- |
 | `use_existing_cloudtrail` | Set this to `true` to use an existing CloudTrail.         | `bool`   |
 | `bucket_arn`              | The S3 bucket ARN configured in the existing CloudTrail.  | `string` |
+| `cloudtrail_name`         | The name of the existing CloudTrail                       | `string` |
 
 **IMPORTANT:** This example does not modify your CloudTrail, therefore, you must enable
 SNS delivery notifications manually and point to the generated SNS topic.
@@ -41,6 +44,7 @@ module "lacework_cloudtrail" {
 
   use_existing_cloudtrail = true
   bucket_arn              = "bucket ARN from existing cloudtrail"
+  cloudtrail_name         = "lacework-cloudtrail"
 }
 ```
 

--- a/examples/existing-cloudtrail-without-sns-topic/main.tf
+++ b/examples/existing-cloudtrail-without-sns-topic/main.tf
@@ -9,6 +9,7 @@ module "aws_cloudtrail" {
 
   # Use an existing CloudTrail
   use_existing_cloudtrail = true
-  bucket_arn              = "arn:aws:s3:::lacework-ct-bucket-8805c0bf"
-  bucket_name             = "lacework-ct-bucket-8805c0bf"
+  bucket_arn              = "arn:aws:s3:::lacework-ct-bucket-4d857633"
+  bucket_name             = "lacework-ct-bucket-4d857633"
+  cloudtrail_name         = "lacework-cloudtrail"
 }

--- a/main.tf
+++ b/main.tf
@@ -358,8 +358,16 @@ data "aws_iam_policy_document" "sns_topic_policy" {
     for_each = !var.use_s3_bucket_notification ? [1] : []
     content {
       actions   = ["SNS:Publish"]
-      sid       = "AWSCloudTrailSNSPolicy20131101"
+      sid       = "AWSCloudTrailSNSPolicy20150319"
       resources = [local.sns_topic_arn]
+
+      effect = "Allow"
+
+      condition {
+        test = "StringEquals"
+        variable = "AWS:SourceArn"
+        values = ["arn:aws:cloudtrail:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:trail/${var.cloudtrail_name}"]
+      }
 
       principals {
         type        = "Service"


### PR DESCRIPTION
## Summary

AWS changes the policy when a new SNS topic is attached to an existing CloudTrail.  This change updates the policy in the HCL to match.

## How did you test this change?

1) Run `terraform apply` in `examples/existing-cloudtrail-without-sns-topic`
2) Add the created SNS topic ARN to the existing CT
3) Run `terraform plan`

## Issue

https://github.com/lacework/terraform-aws-cloudtrail/issues/110
https://lacework.atlassian.net/browse/GROW-1498
