### PR TITLE
fix(policy): publish to SNS from multiple trails

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -363,10 +363,13 @@ data "aws_iam_policy_document" "sns_topic_policy" {
 
       effect = "Allow"
 
-      condition {
-        test = "StringEquals"
-        variable = "AWS:SourceArn"
-        values = ["arn:aws:cloudtrail:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:trail/${var.cloudtrail_name}"]
+      dynamic "condition" {
+        for_each = !var.consolidated_trail ? [1] : []
+        content {
+          test     = "StringEquals"
+          variable = "AWS:SourceArn"
+          values   = ["arn:aws:cloudtrail:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:trail/${var.cloudtrail_name}"]
+        }
       }
 
       principals {


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary
We recently discovered that change
https://github.com/lacework/terraform-aws-cloudtrail/pull/111 broke our consolidated CloudTrail integration since the SNS policy denied by default any other `trail` to publish to it.

The error that users might experience is:
```
│ Error: Error creating CloudTrail: InsufficientSnsTopicPolicyException: SNS Topic does not exist or the topic policy is incorrect!
```

This change fixes this issue by not adding this restriction when the user is integrating multiple trails into one (consolidated trails)


## How did you test this change?

I have used our internal project https://github.com/lacework/terraform-customerdemo that caught this issue
and validated that both, consolidated and non-consolidated integration paths work as expected.

## Issue

Jira: https://lacework.atlassian.net/browse/GROW-1524
