### PR TITLE
fix: s3 bucket ownership controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Terraform module for configuring an integration with Lacework and AWS for CloudT
 | [aws_kms_key.lacework_kms_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_s3_bucket.cloudtrail_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket.cloudtrail_log_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_ownership_controls.cloudtrail_bucket_ownership_controls](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
+| [aws_s3_bucket_ownership_controls.cloudtrail_log_bucket_ownership_controls](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
 | [aws_s3_bucket_acl.cloudtrail_log_bucket_acl](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl) | resource |
 | [aws_s3_bucket_logging.cloudtrail_bucket_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_logging) | resource |
 | [aws_s3_bucket_notification.cloudtrail_bucket_notification](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_notification) | resource |

--- a/main.tf
+++ b/main.tf
@@ -69,6 +69,15 @@ resource "aws_s3_bucket" "cloudtrail_bucket" {
   tags          = var.tags
 }
 
+resource "aws_s3_bucket_ownership_controls" "cloudtrail_bucket_ownership_controls" {
+  count  = var.use_existing_cloudtrail ? 0 : 1
+  bucket = aws_s3_bucket.cloudtrail_bucket[0].id
+
+  rule {
+    object_ownership = "ObjectWriter"
+  }
+}
+
 // v4 s3 bucket changes
 resource "aws_s3_bucket_logging" "cloudtrail_bucket_logging" {
   count         = var.bucket_logs_enabled && !var.use_existing_cloudtrail ? 1 : 0
@@ -136,6 +145,15 @@ resource "aws_s3_bucket" "cloudtrail_log_bucket" {
   bucket        = local.log_bucket_name
   force_destroy = var.bucket_force_destroy
   tags          = var.tags
+}
+
+resource "aws_s3_bucket_ownership_controls" "cloudtrail_log_bucket_ownership_controls" {
+  count  = (var.use_existing_cloudtrail || var.use_existing_access_log_bucket) ? 0 : (var.bucket_logs_enabled ? 1 : 0)
+  bucket = aws_s3_bucket.cloudtrail_log_bucket[0].id
+
+  rule {
+    object_ownership = "ObjectWriter"
+  }
 }
 
 // v4 s3 log bucket changes


### PR DESCRIPTION
## Summary

To enable bucket ACL the `ObjectOwnership` parameter must be set to `ObjectWriter`.

https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html
https://aws.amazon.com/blogs/aws/heads-up-amazon-s3-security-changes-are-coming-in-april-of-2023/

## How did you test this change?

https://g.codefresh.io/build/64391961e8a80758c043e517?step=TerraformPlan&tab=output&logs=terminal

## Issue

https://lacework.atlassian.net/browse/GROW-1534

