### PR TITLE
CloudTrail: Object-level logging

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -59,6 +59,21 @@ resource "aws_cloudtrail" "lacework_cloudtrail" {
   sns_topic_name             = var.use_s3_bucket_notification ? null : local.sns_topic_arn
   tags                       = var.tags
   enable_log_file_validation = var.enable_log_file_validation
+
+  dynamic "event_selector" {
+    for_each = var.enable_cloudtrail_s3_management_events ? [1] : []
+    # If enable_cloudtrail_s3_management_events is enabled, create one of the below
+    # blocks. Otherwise, create zero of the below blocks.
+    content {
+      read_write_type           = "All"
+      include_management_events = true
+      
+      data_resource {
+        type   = "AWS::S3::Object"
+        values = ["${aws_s3_bucket.cloudtrail_bucket[0].arn}/*"]
+      }
+    }
+  }
   depends_on                 = [aws_s3_bucket.cloudtrail_bucket]
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -295,3 +295,9 @@ variable "kms_key_multi_region" {
   default     = true
   description = "Whether the KMS key is a multi-region or regional key"
 }
+
+variable "enable_cloudtrail_s3_management_events" {
+  type        = bool
+  default     = false
+  description = "Enable CloudTrail Object-level logging"
+}


### PR DESCRIPTION
## Summary

<!--
 Currently the `terraform-aws-cloudtrail` module does not contain support for Object-level logging, specifically the ability to add an `event_selector` in order to enable said logging.

This need for this functionality originated from the following policies;
- lacework-global-80 (Ensure that Object-level logging for write events is enabled for S3 buckets)
- lacework-global-81 (Ensure that Object-level logging for read events is enabled for S3 buckets)

- Added a dynamic block which can be enabled / disabled based on an associated variable.
- Added a additional variable 

-->

## How did you test this change?

<!--
Swapped the `source` to my local path and ran a `terraform init` against one of our environments. Modules initialized cleanly.
-->

## Issue

<!--
N/A
-->

