### PR TITLE
feat: Add support for AWS provider 5.0

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -2,9 +2,18 @@ terraform {
   required_version = ">= 0.14"
 
   required_providers {
-    aws    = "~> 4.0"
-    random = ">= 2.1"
-    time   = "~> 0.6"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 2.1"
+    }
+    time = {
+      source  = "hashicorp/time"
+      version = "~> 0.6"
+    }
     lacework = {
       source  = "lacework/lacework"
       version = "~> 1.0"


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary

We'd like to use AWS provider 5.0

Remove higher limit, as specified in [TF best practices](https://developer.hashicorp.com/terraform/language/expressions/version-constraints#terraform-core-and-provider-versions) for this case.

## How did you test this change?

`terraform plan` for our infrastructure

```terraform
module "aws_config" {
  # source  = "lacework/config/aws"
  # version = "0.9.0"
  source = "./terraform-aws-config"

  count = module.this.enabled ? 1 : 0

  lacework_integration_name = "${module.this.tags.Name}-cfg"
  iam_role_name             = module.this.id
}

module "cloudtrail" {
  # https://github.com/lacework/terraform-aws-cloudtrail
  # source  = "lacework/cloudtrail/aws"
  # version = "2.6.0"
  source = "./terraform-aws-cloudtrail"

  count = module.this.enabled && var.cloudtrail_enabled ? 1 : 0

  lacework_integration_name = "${module.this.tags.Name}-ct"
  use_existing_iam_role     = true
  iam_role_arn              = module.aws_config[0].iam_role_arn
  iam_role_external_id      = module.aws_config[0].external_id
  iam_role_name             = module.aws_config[0].iam_role_name

  bucket_name               = module.this.id
  cloudtrail_name           = module.this.id
  cross_account_policy_name = module.this.id
  log_bucket_name           = "${module.this.id}-log"
  sns_topic_name            = module.this.id
  sqs_queue_name            = module.this.id
}

```

## Issue

Relates to https://github.com/lacework/terraform-aws-config/pull/65
Close https://github.com/lacework/terraform-aws-cloudtrail/issues/124
Close https://github.com/lacework/terraform-aws-cloudtrail/pull/125
