### PR TITLE
fix: S3 bucket ACL dependency

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -227,11 +227,14 @@ resource "aws_s3_bucket_ownership_controls" "cloudtrail_log_bucket_ownership_con
 
 // v4 s3 log bucket changes
 resource "aws_s3_bucket_acl" "cloudtrail_log_bucket_acl" {
-  count  = (var.use_existing_cloudtrail || var.use_existing_access_log_bucket) ? 0 : (var.bucket_logs_enabled ? 1 : 0)
-  bucket = aws_s3_bucket.cloudtrail_log_bucket[0].id
-  acl    = "log-delivery-write"
+  count      = (var.use_existing_cloudtrail || var.use_existing_access_log_bucket) ? 0 : (var.bucket_logs_enabled ? 1 : 0)
+  bucket     = aws_s3_bucket.cloudtrail_log_bucket[0].id
+  acl        = "log-delivery-write"
+  depends_on = [
+    aws_s3_bucket_public_access_block.cloudtrail_log_bucket_access,
+    aws_s3_bucket_ownership_controls.cloudtrail_bucket_ownership_controls
+  ]
 }
-
 
 resource "aws_s3_bucket_versioning" "cloudtrail_log_bucket_versioning" {
   count  = (var.use_existing_cloudtrail || var.use_existing_access_log_bucket) ? 0 : (var.bucket_logs_enabled ? 1 : 0)


### PR DESCRIPTION
## Summary

It is possible for the S3 bucket ACL resource to be created before the ownership controls, leading a failure to apply the ACL.  We need to define an explicit dependency.

## How did you test this change?

https://g.codefresh.io/build/6480402325053f6cc74dc5fa no changes in TF plan.  This code change just sets order of the creation of resources.

## Issue

https://lacework.atlassian.net/browse/GROW-1835
