### PR TITLE
chore: enable bucket_force_destroy by default

### DIFF
--- a/DEVELOPER_GUIDELINES.md
+++ b/DEVELOPER_GUIDELINES.md
@@ -94,7 +94,6 @@ module "aws_cloudtrail" {
   source  = "lacework/cloudtrail/aws"
   version = "~> 1.0"
 
-  bucket_force_destroy  = true
   use_existing_iam_role = true
   iam_role_name         = module.aws_config.iam_role_name
   iam_role_arn          = module.aws_config.iam_role_arn

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Terraform module for configuring an integration with Lacework and AWS for CloudT
 | <a name="input_bucket_arn"></a> [bucket\_arn](#input\_bucket\_arn) | The S3 bucket ARN is required when setting use\_existing\_cloudtrail to true | `string` | `""` | no |
 | <a name="input_bucket_enable_mfa_delete"></a> [bucket\_enable\_mfa\_delete](#input\_bucket\_enable\_mfa\_delete) | Set this to `true` to require MFA for object deletion (Requires versioning) | `bool` | `false` | no |
 | <a name="input_bucket_encryption_enabled"></a> [bucket\_encryption\_enabled](#input\_bucket\_encryption\_enabled) | Set this to `true` to enable encryption on a created S3 bucket | `bool` | `true` | no |
-| <a name="input_bucket_force_destroy"></a> [bucket\_force\_destroy](#input\_bucket\_force\_destroy) | Force destroy bucket (Required when bucket not empty) | `bool` | `false` | no |
+| <a name="input_bucket_force_destroy"></a> [bucket\_force\_destroy](#input\_bucket\_force\_destroy) | Force destroy bucket (if disabled, terraform will not be able do destroy non-empty bucket) | `bool` | `true` | no |
 | <a name="input_bucket_logs_enabled"></a> [bucket\_logs\_enabled](#input\_bucket\_logs\_enabled) | Set this to `true` to enable access logging on a created S3 bucket | `bool` | `true` | no |
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | Optional value to specify name for a newly created S3 bucket. Not required when `use_existing_cloudtrail` is true. | `string` | `""` | no |
 | <a name="input_bucket_sse_algorithm"></a> [bucket\_sse\_algorithm](#input\_bucket\_sse\_algorithm) | The encryption algorithm to use for S3 bucket server-side encryption | `string` | `"aws:kms"` | no |

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Terraform module for configuring an integration with Lacework and AWS for CloudT
 | <a name="input_bucket_arn"></a> [bucket\_arn](#input\_bucket\_arn) | The S3 bucket ARN is required when setting use\_existing\_cloudtrail to true | `string` | `""` | no |
 | <a name="input_bucket_enable_mfa_delete"></a> [bucket\_enable\_mfa\_delete](#input\_bucket\_enable\_mfa\_delete) | Set this to `true` to require MFA for object deletion (Requires versioning) | `bool` | `false` | no |
 | <a name="input_bucket_encryption_enabled"></a> [bucket\_encryption\_enabled](#input\_bucket\_encryption\_enabled) | Set this to `true` to enable encryption on a created S3 bucket | `bool` | `true` | no |
-| <a name="input_bucket_force_destroy"></a> [bucket\_force\_destroy](#input\_bucket\_force\_destroy) | Force destroy bucket (if disabled, terraform will not be able do destroy non-empty bucket) | `bool` | `true` | no |
+| <a name="input_bucket_force_destroy"></a> [bucket\_force\_destroy](#input\_bucket\_force\_destroy) |Force destroy bucket (When 'false' a non-empty bucket will NOT be destroyed.) | `bool` | `true` | no |
 | <a name="input_bucket_logs_enabled"></a> [bucket\_logs\_enabled](#input\_bucket\_logs\_enabled) | Set this to `true` to enable access logging on a created S3 bucket | `bool` | `true` | no |
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | Optional value to specify name for a newly created S3 bucket. Not required when `use_existing_cloudtrail` is true. | `string` | `""` | no |
 | <a name="input_bucket_sse_algorithm"></a> [bucket\_sse\_algorithm](#input\_bucket\_sse\_algorithm) | The encryption algorithm to use for S3 bucket server-side encryption | `string` | `"aws:kms"` | no |

--- a/examples/cloudtrail-existing-kms-key/README.md
+++ b/examples/cloudtrail-existing-kms-key/README.md
@@ -6,7 +6,6 @@ This example creates a new CloudTrail in an AWS account with almost all of the r
 
 | Name                   | Description                                           | Type   |
 | ---------------------- | ----------------------------------------------------- | ------ |
-| `bucket_force_destroy` | Force destroy bucket (Required when bucket not empty) | `bool` |
 | `bucket_sse_key_arn` | The ARN of the KMS encryption key to be used for S3 | `string` |
 | `sns_topic_encryption_key_arn` | The ARN of an existing KMS encryption key to be used for SNS | `string` |
 | `sqs_encryption_key_arn` | The ARN of the KMS encryption key to be used for SQS | `string` |
@@ -28,7 +27,6 @@ resource "aws_kms_key" "lacework_kms_key" {
 module "aws_cloudtrail" {
   source = ">= 2.3.2"
 
-  bucket_force_destroy         = true
   use_existing_kms_key         = true
   bucket_sse_key_arn           = aws_kms_key.lacework_kms_key.arn
   sns_topic_encryption_key_arn = aws_kms_key.lacework_kms_key.arn

--- a/examples/cloudtrail-existing-kms-key/main.tf
+++ b/examples/cloudtrail-existing-kms-key/main.tf
@@ -5,14 +5,13 @@ provider "aws" {
 provider "lacework" {}
 
 resource "aws_kms_key" "lacework_kms_key" {
-  description  = "A KMS key used to encrypt CloudTrail logs which are monitored by Lacework"
-  policy       = data.aws_iam_policy_document.kms_key_policy.json
+  description = "A KMS key used to encrypt CloudTrail logs which are monitored by Lacework"
+  policy      = data.aws_iam_policy_document.kms_key_policy.json
 }
 
 module "aws_cloudtrail" {
   source = "../../"
 
-  bucket_force_destroy         = true
   use_existing_kms_key         = true
   bucket_sse_key_arn           = aws_kms_key.lacework_kms_key.arn
   sns_topic_encryption_key_arn = aws_kms_key.lacework_kms_key.arn
@@ -40,63 +39,63 @@ data "aws_iam_policy_document" "kms_key_policy" {
   }
 
   statement {
-      sid    = "Allow CloudTrail service to encrypt/decrypt"
-      effect = "Allow"
+    sid    = "Allow CloudTrail service to encrypt/decrypt"
+    effect = "Allow"
 
-      principals {
-        type        = "Service"
-        identifiers = ["cloudtrail.amazonaws.com"]
-      }
+    principals {
+      type        = "Service"
+      identifiers = ["cloudtrail.amazonaws.com"]
+    }
 
-      actions   = ["kms:GenerateDataKey*", "kms:Decrypt"]
-      resources = ["*"]
-  }
-
-   statement {
-      sid    = "Allow S3 bucket to encrypt/decrypt"
-      effect = "Allow"
-
-      principals {
-        type        = "Service"
-        identifiers = ["s3.amazonaws.com"]
-      }
-
-      condition {
-        test     = "ArnEquals"
-        variable = "aws:SourceArn"
-        values = [
-          module.aws_cloudtrail.bucket_arn
-        ]
-      }
-
-      actions   = ["kms:GenerateDataKey*", "kms:Decrypt"]
-      resources = ["*"]
+    actions   = ["kms:GenerateDataKey*", "kms:Decrypt"]
+    resources = ["*"]
   }
 
   statement {
-      sid    = "Allow CloudTrail to describe key"
-      effect = "Allow"
+    sid    = "Allow S3 bucket to encrypt/decrypt"
+    effect = "Allow"
 
-      principals {
-        type        = "Service"
-        identifiers = ["cloudtrail.amazonaws.com"]
-      }
+    principals {
+      type        = "Service"
+      identifiers = ["s3.amazonaws.com"]
+    }
 
-      actions   = ["kms:DescribeKey"]
-      resources = ["*"]
+    condition {
+      test     = "ArnEquals"
+      variable = "aws:SourceArn"
+      values = [
+        module.aws_cloudtrail.bucket_arn
+      ]
+    }
+
+    actions   = ["kms:GenerateDataKey*", "kms:Decrypt"]
+    resources = ["*"]
   }
 
   statement {
-      sid    = "Allow SNS service to encrypt/decrypt"
-      effect = "Allow"
+    sid    = "Allow CloudTrail to describe key"
+    effect = "Allow"
 
-      principals {
-        type        = "Service"
-        identifiers = ["sns.amazonaws.com"]
-      }
+    principals {
+      type        = "Service"
+      identifiers = ["cloudtrail.amazonaws.com"]
+    }
 
-      actions   = ["kms:GenerateDataKey*", "kms:Decrypt"]
-      resources = ["*"]
+    actions   = ["kms:DescribeKey"]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "Allow SNS service to encrypt/decrypt"
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["sns.amazonaws.com"]
+    }
+
+    actions   = ["kms:GenerateDataKey*", "kms:Decrypt"]
+    resources = ["*"]
   }
 
   statement {

--- a/examples/complete-cloudtrail-access-logs-with-object-level-logging/README.md
+++ b/examples/complete-cloudtrail-access-logs-with-object-level-logging/README.md
@@ -25,4 +25,4 @@ module "aws_cloudtrail" {
 }
 ```
 
-For detailed information on integrating Lacework with AWS see [AWS Config and CloudTrail Integration with Terraform](https://support.lacework.com/hc/en-us/articles/360057092034-AWS-Config-and-CloudTrail-Integration-with-Terraform)
+For detailed information on integrating Lacework with AWS see [AWS Config and CloudTrail Integration with Terraform](https://docs.lacework.net/onboarding/aws-guided-configuration).

--- a/examples/complete-cloudtrail-access-logs/README.md
+++ b/examples/complete-cloudtrail-access-logs/README.md
@@ -25,4 +25,4 @@ module "aws_cloudtrail" {
 }
 ```
 
-For detailed information on integrating Lacework with AWS see [AWS Config and CloudTrail Integration with Terraform](https://support.lacework.com/hc/en-us/articles/360057092034-AWS-Config-and-CloudTrail-Integration-with-Terraform)
+For detailed information on integrating Lacework with AWS see [AWS Config and CloudTrail Integration with Terraform](https://docs.lacework.net/onboarding/aws-guided-configuration).

--- a/examples/complete-cloudtrail-unencrypted/README.md
+++ b/examples/complete-cloudtrail-unencrypted/README.md
@@ -9,7 +9,6 @@ This example creates a new CloudTrail in an AWS account with all of the required
 | Name                           | Description                                                                | Type   |
 | ------------------------------ | -------------------------------------------------------------------------- | ------ |
 | `bucket_encryption_enabled`    | Set this to `true` to use an existing CloudTrail.                          | `bool` |
-| `bucket_force_destroy`         | Force destroy bucket (Required when bucket not empty)                      | `bool` |
 | `sns_topic_encryption_enabled` | Set this to `false` to disable encryption on a sns topic. Defaults to true | `bool` |
 | `sqs_encryption_enabled`       | Set this to `true` to enable server-side encryption on SQS.                | `bool` |
 
@@ -27,10 +26,9 @@ module "aws_cloudtrail" {
   version = "~> 1.0"
 
   bucket_encryption_enabled    = false
-  bucket_force_destroy         = true
   sns_topic_encryption_enabled = false
   sqs_encryption_enabled       = false
 }
 ```
 
-For detailed information on integrating Lacework with AWS see [AWS Config and CloudTrail Integration with Terraform](https://support.lacework.com/hc/en-us/articles/360057092034-AWS-Config-and-CloudTrail-Integration-with-Terraform).
+For detailed information on integrating Lacework with AWS see [AWS Config and CloudTrail Integration with Terraform](https://docs.lacework.net/onboarding/aws-guided-configuration).

--- a/examples/complete-cloudtrail-unencrypted/main.tf
+++ b/examples/complete-cloudtrail-unencrypted/main.tf
@@ -8,7 +8,6 @@ module "aws_cloudtrail" {
   source = "../../"
 
   bucket_encryption_enabled    = false
-  bucket_force_destroy         = true
   sns_topic_encryption_enabled = false
   sqs_encryption_enabled       = false
 }

--- a/examples/complete-cloudtrail-versioning/README.md
+++ b/examples/complete-cloudtrail-versioning/README.md
@@ -27,4 +27,4 @@ module "aws_cloudtrail" {
 }
 ```
 
-For detailed information on integrating Lacework with AWS see [AWS Config and CloudTrail Integration with Terraform](https://support.lacework.com/hc/en-us/articles/360057092034-AWS-Config-and-CloudTrail-Integration-with-Terraform)
+For detailed information on integrating Lacework with AWS see [AWS Config and CloudTrail Integration with Terraform](https://docs.lacework.net/onboarding/aws-guided-configuration).

--- a/examples/complete-cloudtrail/README.md
+++ b/examples/complete-cloudtrail/README.md
@@ -1,12 +1,8 @@
 # Deploy New CloudTrail and Integrate with Lacework
 
-This example creates a new CloudTrail in an AWS account with all of the required resources, as well as creating an IAM Role with a cross-account policy to provide Lacework read-only access to monitor the trail.
-
-## Inputs
-
-| Name                   | Description                                           | Type   |
-| ---------------------- | ----------------------------------------------------- | ------ |
-| `bucket_force_destroy` | Force destroy bucket (Required when bucket not empty) | `bool` |
+This example creates a new CloudTrail in an AWS account with all of the required resources,
+as well as creating an IAM Role with a cross-account policy to provide Lacework read-only
+access to monitor the trail.
 
 ## Sample Code
 
@@ -19,10 +15,8 @@ provider "lacework" {}
 
 module "aws_cloudtrail" {
   source  = "lacework/cloudtrail/aws"
-  version = "~> 1.0"
-
-  bucket_force_destroy  = true
+  version = "~> 2.0"
 }
 ```
 
-For detailed information on integrating Lacework with AWS see [AWS Config and CloudTrail Integration with Terraform](https://support.lacework.com/hc/en-us/articles/360057092034-AWS-Config-and-CloudTrail-Integration-with-Terraform).
+For detailed information on integrating Lacework with AWS see [AWS Config and CloudTrail Integration with Terraform](https://docs.lacework.net/onboarding/aws-guided-configuration).

--- a/examples/complete-cloudtrail/main.tf
+++ b/examples/complete-cloudtrail/main.tf
@@ -6,6 +6,4 @@ provider "lacework" {}
 
 module "aws_cloudtrail" {
   source = "../../"
-
-  bucket_force_destroy = true
 }

--- a/examples/consolidated-cloudtrail-multiple-lacework-tenants/README.md
+++ b/examples/consolidated-cloudtrail-multiple-lacework-tenants/README.md
@@ -85,4 +85,4 @@ resource "aws_cloudtrail" "sub_account_2" {
 }
 ```
 
-For detailed information on integrating Lacework with AWS see [AWS Config and CloudTrail Integration with Terraform](https://support.lacework.com/hc/en-us/articles/360057092034-AWS-Config-and-CloudTrail-Integration-with-Terraform)
+For detailed information on integrating Lacework with AWS see [AWS Config and CloudTrail Integration with Terraform](https://docs.lacework.net/onboarding/aws-guided-configuration).

--- a/examples/consolidated-cloudtrail/README.md
+++ b/examples/consolidated-cloudtrail/README.md
@@ -22,7 +22,7 @@ provider "aws" {
 
 module "main_cloudtrail" {
   source  = "lacework/cloudtrail/aws"
-  version = "~> 1.0"
+  version = "~> 2.0"
   providers = {
     aws      = aws.main-account
     lacework = lacework.main-account
@@ -68,4 +68,4 @@ resource "aws_cloudtrail" "sub_account_2" {
 }
 ```
 
-For detailed information on integrating Lacework with AWS see [AWS Config and CloudTrail Integration with Terraform](https://support.lacework.com/hc/en-us/articles/360057092034-AWS-Config-and-CloudTrail-Integration-with-Terraform)
+For detailed information on integrating Lacework with AWS see [AWS Config and CloudTrail Integration with Terraform](https://docs.lacework.net/onboarding/aws-guided-configuration).

--- a/examples/existing-cloudtrail-end-to-end-encryption/README.md
+++ b/examples/existing-cloudtrail-end-to-end-encryption/README.md
@@ -68,4 +68,4 @@ module "aws_cloudtrail" {
 }
 ```
 
-For detailed information on integrating Lacework with AWS see [AWS Config and CloudTrail Integration with Terraform](https://support.lacework.com/hc/en-us/articles/360057092034-AWS-Config-and-CloudTrail-Integration-with-Terraform)
+For detailed information on integrating Lacework with AWS see [AWS Config and CloudTrail Integration with Terraform](https://docs.lacework.net/onboarding/aws-guided-configuration).

--- a/examples/existing-cloudtrail-iam-role/README.md
+++ b/examples/existing-cloudtrail-iam-role/README.md
@@ -44,4 +44,4 @@ module "aws_cloudtrail" {
 }
 ```
 
-For detailed information on integrating Lacework with AWS see [AWS Config and CloudTrail Integration with Terraform](https://support.lacework.com/hc/en-us/articles/360057092034-AWS-Config-and-CloudTrail-Integration-with-Terraform)
+For detailed information on integrating Lacework with AWS see [AWS Config and CloudTrail Integration with Terraform](https://docs.lacework.net/onboarding/aws-guided-configuration).

--- a/examples/existing-cloudtrail-s3-encryption/README.md
+++ b/examples/existing-cloudtrail-s3-encryption/README.md
@@ -41,4 +41,4 @@ module "aws_cloudtrail" {
 }
 ```
 
-For detailed information on integrating Lacework with AWS see [AWS Config and CloudTrail Integration with Terraform](https://support.lacework.com/hc/en-us/articles/360057092034-AWS-Config-and-CloudTrail-Integration-with-Terraform)
+For detailed information on integrating Lacework with AWS see [AWS Config and CloudTrail Integration with Terraform](https://docs.lacework.net/onboarding/aws-guided-configuration).

--- a/examples/existing-cloudtrail-s3-notifications/README.md
+++ b/examples/existing-cloudtrail-s3-notifications/README.md
@@ -32,4 +32,4 @@ module "aws_cloudtrail" {
 }
 ```
 
-For detailed information on integrating Lacework with AWS see [AWS Config and CloudTrail Integration with Terraform](https://support.lacework.com/hc/en-us/articles/360057092034-AWS-Config-and-CloudTrail-Integration-with-Terraform)
+For detailed information on integrating Lacework with AWS see [AWS Config and CloudTrail Integration with Terraform](https://docs.lacework.net/onboarding/aws-guided-configuration).

--- a/examples/existing-cloudtrail-without-sns-topic/README.md
+++ b/examples/existing-cloudtrail-without-sns-topic/README.md
@@ -48,4 +48,4 @@ module "lacework_cloudtrail" {
 }
 ```
 
-For detailed information on integrating Lacework with AWS see [AWS Config and CloudTrail Integration with Terraform](https://support.lacework.com/hc/en-us/articles/360057092034-AWS-Config-and-CloudTrail-Integration-with-Terraform)
+For detailed information on integrating Lacework with AWS see [AWS Config and CloudTrail Integration with Terraform](https://docs.lacework.net/onboarding/aws-guided-configuration).

--- a/variables.tf
+++ b/variables.tf
@@ -127,7 +127,7 @@ variable "bucket_versioning_enabled" {
 variable "bucket_force_destroy" {
   type        = bool
   default     = true
-  description = "Force destroy bucket (if disabled, terraform will not be able do destroy non-empty bucket)"
+  description = "Force destroy bucket (When 'false' a non-empty bucket will NOT be destroyed.)"
 }
 
 variable "bucket_sse_algorithm" {

--- a/variables.tf
+++ b/variables.tf
@@ -126,8 +126,8 @@ variable "bucket_versioning_enabled" {
 
 variable "bucket_force_destroy" {
   type        = bool
-  default     = false
-  description = "Force destroy bucket (Required when bucket not empty)"
+  default     = true
+  description = "Force destroy bucket (if disabled, terraform will not be able do destroy non-empty bucket)"
 }
 
 variable "bucket_sse_algorithm" {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary

When we use this module to automatically deploy and rollback changes. Users are having
constant issues trying to destroy the S3 bucket if it is not empty. To unblock this problem,
users need to turn on the `bucket_force_destroy` flag, and then do any modification that
requires a "destroy" operation.

By default, we should allow users to do these operations without the need to know about
this flag, if users does not wish to allow these buckets to be destroyed when they are not
empty, users should switch off the flag with `bucket_force_destroy = false`.

## How did you test this change?

After merge, we will run our internal pipeline https://github.com/lacework/terraform-customerdemo/pull/70

## Issue
https://lacework.atlassian.net/browse/GROW-1336
