### PR TITLE
fix: KMS least privileged access

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -182,7 +182,7 @@ data "aws_iam_policy_document" "cloudtrail_log_policy" {
 
     principals {
       type        = "AWS"
-      identifiers = ["*"]
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
     }
 
     condition {
@@ -356,7 +356,7 @@ data "aws_iam_policy_document" "kms_key_policy" {
 
     principals {
       type        = "AWS"
-      identifiers = ["*"]
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
     }
 
     actions = [
@@ -364,12 +364,6 @@ data "aws_iam_policy_document" "kms_key_policy" {
       "kms:ReEncryptFrom"
     ]
     resources = ["*"]
-
-    condition {
-      test     = "StringEquals"
-      variable = "kms:CallerAccount"
-      values   = [data.aws_caller_identity.current.account_id]
-    }
 
     condition {
       test     = "StringLike"


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary
Customer reported that the CloudTrail that LW created was being flagged as having a publicly accessible KMS key.

## How did you test this change?
Updated the KMS policy to remove the * for the principal and added the caller

```
   principals {
      type        = "AWS"
      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
    }
```
the new terraform was applied and the integration was successfully updated. Checking on a test AWS account the actual policy can be seen below

![image](https://github.com/lacework/terraform-aws-cloudtrail/assets/87976925/34dda658-e0a5-419c-8004-4ca8ff51120a)

Integration creation was successful 

![image](https://github.com/lacework/terraform-aws-cloudtrail/assets/87976925/0c3740f2-730b-46c0-beef-0d56167a938a)


## Issue
The issue is covered in a number of JIRA tickets, here 

Original Link ticket        https://lacework.atlassian.net/browse/LINK-1795
Parent Dev ticket.          https://lacework.atlassian.net/browse/GROW-2303
Ticket for this change.  https://lacework.atlassian.net/browse/GROW-2319           

