### PR TITLE
chore(output): ARN of the KMS encryption key used for S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Terraform module for configuring an integration with Lacework and AWS for CloudT
 |------|-------------|
 | <a name="output_bucket_arn"></a> [bucket\_arn](#output\_bucket\_arn) | S3 Bucket ARN |
 | <a name="output_bucket_name"></a> [bucket\_name](#output\_bucket\_name) | S3 Bucket name |
+| <a name="output_bucket_sse_key_arn"></a> [bucket\_sse\_key\_arn](#output\_bucket\_sse\_key\_arn) | The ARN of the KMS encryption key used for S3 |
 | <a name="output_external_id"></a> [external\_id](#output\_external\_id) | The External ID configured into the IAM role |
 | <a name="output_iam_role_arn"></a> [iam\_role\_arn](#output\_iam\_role\_arn) | The IAM Role ARN |
 | <a name="output_iam_role_name"></a> [iam\_role\_name](#output\_iam\_role\_name) | The IAM Role name |

--- a/output.tf
+++ b/output.tf
@@ -52,3 +52,8 @@ output "lacework_integration_guid" {
   value       = local.lacework_integration_guid
   description = "Lacework CloudTrail Integration GUID"
 }
+
+output "bucket_sse_key_arn" {
+  value       = local.bucket_sse_key_arn
+  description = "The ARN of the KMS encryption key used for S3"
+}


### PR DESCRIPTION
## Summary

Adds `bucket_sse_key_arn` output to allow module and resource chaining. This new output
holds the ARN of the KMS encryption key used for S3.

## How did you test this change?

CI will succeed and I ran `terraform output` locally.

## Issue

N/A
