### PR TITLE
fix: log_bucket deny policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -182,7 +182,7 @@ data "aws_iam_policy_document" "cloudtrail_log_policy" {
 
     principals {
       type        = "AWS"
-      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+      identifiers = ["*"]
     }
 
     condition {


### PR DESCRIPTION
## Summary

AWS S3 are changing the behaviour of S3 deny policies that refer to the root account.  The root account identifier will be expanded to include all principles in the account.

This is a lint exercise.

https://www.k9security.io/posts/2023/10/how-s3-is-changing-the-handling-of-the-root-identity-in-bucket-policy-on-october-20-2023/

## How did you test this change?


## Issue

https://lacework.atlassian.net/browse/GROW-2444
