### PR TITLE
Use `sns_topic_name` instead of `sns_topic_arn`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -61,7 +61,7 @@ resource "aws_cloudtrail" "lacework_cloudtrail" {
   is_organization_trail      = var.is_organization_trail
   s3_bucket_name             = local.bucket_name
   kms_key_id                 = local.bucket_sse_key_arn
-  sns_topic_name             = var.use_s3_bucket_notification ? null : local.sns_topic_arn
+  sns_topic_name             = var.use_s3_bucket_notification ? null : local.sns_topic_name
   tags                       = var.tags
   enable_log_file_validation = var.enable_log_file_validation
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

The `aws_cloudtrail.lacework_cloudtrail` resources expects a `sns_topic_name`.

```
Terraform will perform the following actions:

  # module.lacework_aws_cloudtrail.aws_cloudtrail.lacework_cloudtrail[0] will be updated in-place
  ~ resource "aws_cloudtrail" "lacework_cloudtrail" {
        id                            = "arn:aws:cloudtrail:us-west-1:667005031541:trail/lacework-cloudtrail"
        name                          = "lacework-cloudtrail"
      ~ sns_topic_name                = "lacework-ct-sns-7374a5e3" -> "arn:aws:sns:us-west-1:667005031541:lacework-ct-sns-7374a5e3"
        tags                          = {}
        # (14 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

This changes fixes a drift that constantly tries to set the `sns_topic_arn` to the `sns_topic_name` argument.

## How did you test this change?

I locally tried this change with a `terraform plan`:
```
No changes. Your infrastructure matches the configuration.
```


<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

## Issue

<!--
  Include the link to a Jira/Github issue
-->

