### PR TITLE
fix: lacework_cloudtrail should depend on lacework_cloudtrail_sns_topic

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -79,7 +79,10 @@ resource "aws_cloudtrail" "lacework_cloudtrail" {
       }
     }
   }
-  depends_on = [aws_s3_bucket.cloudtrail_bucket]
+  depends_on = [
+    aws_s3_bucket.cloudtrail_bucket,
+    aws_sns_topic.lacework_cloudtrail_sns_topic
+  ]
 }
 
 resource "aws_s3_bucket" "cloudtrail_bucket" {


### PR DESCRIPTION
## Summary

The following error is introduced by https://github.com/lacework/terraform-aws-cloudtrail/pull/168

```
Name: AWS CloudTrail, Status: failed, Error: failed to run terraform apply: exit status 1
Error: creating CloudTrail Trail (lacework-cloudtrail-1af4c7f3): operation error 
CloudTrail: CreateTrail, https response error StatusCode: 400, 
RequestID: 9f5cac78-22bf-4646-9645-a992d0b878d5, 
InsufficientSnsTopicPolicyException: SNS Topic does not exist or the topic policy is incorrect! 
```

Add `aws_sns_topic.lacework_cloudtrail_sns_topic` as a dependency of `aws_cloudtrail.lacework_cloudtrail` to fix it.

## How did you test this change?
`terraform apply` runs correctly now.
<img width="950" alt="Screenshot 2025-02-18 at 7 14 04 AM" src="https://github.com/user-attachments/assets/0f8133da-72b0-4ca0-9156-eadf1e37df23" />

