### PR TITLE
feat: allow users to specify additional users for kms key policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Terraform module for configuring an integration with Lacework and AWS for CloudT
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_access_log_prefix"></a> [access\_log\_prefix](#input\_access\_log\_prefix) | Optional value to specify a key prefix for access log objects for logging S3 bucket | `string` | `"log/"` | no |
+| <a name="input_additional_kms_key_policy_users"></a> [additional\_kms\_key\_policy\_users](#input\_additional\_kms\_key\_policy\_users) | Optional list of additional IAM user ARNs to be included in the KMS key policy | `list(string)` | `[]` | no |
 | <a name="input_bucket_arn"></a> [bucket\_arn](#input\_bucket\_arn) | The S3 bucket ARN is required when setting use\_existing\_cloudtrail to true | `string` | `""` | no |
 | <a name="input_bucket_enable_mfa_delete"></a> [bucket\_enable\_mfa\_delete](#input\_bucket\_enable\_mfa\_delete) | Set this to `true` to require MFA for object deletion (Requires versioning) | `bool` | `false` | no |
 | <a name="input_bucket_encryption_enabled"></a> [bucket\_encryption\_enabled](#input\_bucket\_encryption\_enabled) | Set this to `true` to enable encryption on a created S3 bucket | `bool` | `true` | no |

--- a/main.tf
+++ b/main.tf
@@ -289,6 +289,22 @@ data "aws_iam_policy_document" "kms_key_policy" {
   }
 
   dynamic "statement" {
+    for_each = var.additional_kms_key_policy_users
+    content {
+      sid    = "AllowAdditionalUser-${statement.value}"
+      effect = "Allow"
+
+      principals {
+        type        = "AWS"
+        identifiers = [statement.value]
+      }
+
+      actions   = ["kms:*"]
+      resources = ["*"]
+    }
+  }
+
+  dynamic "statement" {
     for_each = (!var.use_existing_cloudtrail && length(var.bucket_sse_key_arn) == 0) || var.sns_topic_encryption_enabled ? [1] : []
     content {
       sid    = "AllowCloudTrailServiceToEncryptDecrypt"

--- a/variables.tf
+++ b/variables.tf
@@ -307,3 +307,9 @@ variable "cross_account_cloudtrail_arn" {
   default     = null
   description = "If using an existing CloudTrail in another account, provide the ARN here"
 }
+
+variable "additional_kms_key_policy_users" {
+  type        = list(string)
+  default     = []
+  description = "Optional list of additional IAM user ARNs to be included in the KMS key policy"
+}


### PR DESCRIPTION
## Summary

In environments where customers have managed service providers with shared access to administer kms keys there is a need to allow the lacework KMS to be provisioned (optionally) with an extended list of trusted identities.

## How did you test this change?

Deployed to test environment.

## Issue

Raised via customer NFR:
https://mantis.fortinet.com/bug_view_page.php?bug_id=1117782
