### PR TITLE
Replace deprecated `name` attribute

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -33,7 +33,7 @@ locals {
   bucket_encryption_enabled = var.bucket_encryption_enabled && length(local.bucket_sse_key_arn) > 0
   bucket_versioning_enabled = var.bucket_versioning_enabled ? "Enabled" : "Suspended"
   bucket_sse_key_arn        = var.use_existing_kms_key ? var.bucket_sse_key_arn : ((var.use_existing_cloudtrail || length(var.bucket_sse_key_arn) > 0) ? var.bucket_sse_key_arn : aws_kms_key.lacework_kms_key[0].arn)
-  cloudtrail_arn = var.consolidated_trail && var.use_existing_cloudtrail && var.cross_account_cloudtrail_arn != null ? var.cross_account_cloudtrail_arn : "arn:aws:cloudtrail:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:trail/${var.cloudtrail_name}"
+  cloudtrail_arn = var.consolidated_trail && var.use_existing_cloudtrail && var.cross_account_cloudtrail_arn != null ? var.cross_account_cloudtrail_arn : "arn:aws:cloudtrail:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:trail/${var.cloudtrail_name}"
   version_file   = "${abspath(path.module)}/VERSION"
   module_name    = "terraform-aws-cloudtrail"
   module_version = fileexists(local.version_file) ? file(local.version_file) : ""


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-cloudtrail/blob/main/CONTRIBUTING.md
--->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

Fixes the following warning:
```
│ Warning: Deprecated attribute
│
│   on .terraform/modules/lacework_aws_cloudtrail/main.tf line 36, in locals:
│   36:   cloudtrail_arn = var.consolidated_trail && var.use_existing_cloudtrail && var.cross_account_cloudtrail_arn != null ? var.cross_account_cloudtrail_arn : "arn:aws:cloudtrail:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:trail/${var.cloudtrail_name}"
│
│ The attribute "name" is deprecated. Refer to the provider documentation for details.
```

## How did you test this change?

```
$ terraform plan
No changes. Your infrastructure matches the configuration.
```
<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->
